### PR TITLE
Introduce `Bus`

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		871932072C30E91D00A73C22 /* NESColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871932062C30E91D00A73C22 /* NESColor.swift */; };
 		871932092C30F5C700A73C22 /* NESColor+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871932082C30F5C700A73C22 /* NESColor+SwiftUI.swift */; };
 		8719320C2C3366B000A73C22 /* Console.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719320A2C3366A900A73C22 /* Console.swift */; };
+		871932102C372F6900A73C22 /* Bus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719320F2C372F6900A73C22 /* Bus.swift */; };
 		8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1762C1CB9B3001B44B5 /* happiNESs.docc */; };
 		8744B17D2C1CB9B3001B44B5 /* happiNESs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8744B1722C1CB9B3001B44B5 /* happiNESs.framework */; };
 		8744B1822C1CB9B3001B44B5 /* CPUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1812C1CB9B3001B44B5 /* CPUTests.swift */; };
@@ -69,6 +70,7 @@
 		871932062C30E91D00A73C22 /* NESColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESColor.swift; sourceTree = "<group>"; };
 		871932082C30F5C700A73C22 /* NESColor+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NESColor+SwiftUI.swift"; sourceTree = "<group>"; };
 		8719320A2C3366A900A73C22 /* Console.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Console.swift; path = happiNESsApp/Console.swift; sourceTree = SOURCE_ROOT; };
+		8719320F2C372F6900A73C22 /* Bus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bus.swift; sourceTree = "<group>"; };
 		8744B1722C1CB9B3001B44B5 /* happiNESs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = happiNESs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8744B1752C1CB9B3001B44B5 /* happiNESs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = happiNESs.h; sourceTree = "<group>"; };
 		8744B1762C1CB9B3001B44B5 /* happiNESs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = happiNESs.docc; sourceTree = "<group>"; };
@@ -163,11 +165,12 @@
 				8744B1752C1CB9B3001B44B5 /* happiNESs.h */,
 				8744B1762C1CB9B3001B44B5 /* happiNESs.docc */,
 				8744B18C2C1CB9F4001B44B5 /* AddressingMode.swift */,
+				8719320F2C372F6900A73C22 /* Bus.swift */,
 				8744B1902C1CC0C4001B44B5 /* CPU.swift */,
+				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 				871932062C30E91D00A73C22 /* NESColor.swift */,
 				8744B18E2C1CBB46001B44B5 /* Opcode.swift */,
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
-				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 			);
 			path = happiNESs;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,
+				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/happiNESs.xcodeproj/xcuserdata/danielle.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/happiNESs.xcodeproj/xcuserdata/danielle.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>happiNESs.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>happiNESsApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -28,7 +28,7 @@ extension Bus {
             let ppuAddress = Int(address & 0b0010_0000_0000_0111)
             fatalError("TODO! Implement PPU access!")
         default:
-            print("TODO: Implement memory access for this address")
+            print("TODO: Implement memory reading for this address: \(address)")
             return 0x00
         }
     }
@@ -42,7 +42,7 @@ extension Bus {
             let ppuAddress = Int(address & 0b0010_0000_0000_0111)
             fatalError("TODO! Implement PPU access!")
         default:
-            print("TODO: Implement memory access for this address")
+            print("TODO: Implement memory writing for this address: \(address)")
         }
     }
 }

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -1,0 +1,48 @@
+//
+//  Bus.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 7/4/24.
+//
+
+public struct Bus {
+    static let ramMirrorsBegin: UInt16 = 0x0000;
+    static let ramMirrorsEnd: UInt16 = 0x1FFF;
+    static let ppuRegistersMirrorsBegin: UInt16 = 0x2000;
+    static let ppuRegistersMirrorsEnd: UInt16 = 0x3FFF;
+
+    var vram: [UInt8]
+
+    init() {
+        self.vram = [UInt8](repeating: 0x00, count: 2048)
+    }
+}
+
+extension Bus {
+    func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case Self.ramMirrorsBegin ... Self.ramMirrorsEnd:
+            let vramAddress = Int(address & 0b0000_0111_1111_1111)
+            return self.vram[vramAddress]
+        case Self.ppuRegistersMirrorsBegin ... Self.ppuRegistersMirrorsEnd:
+            let ppuAddress = Int(address & 0b0010_0000_0000_0111)
+            fatalError("TODO! Implement PPU access!")
+        default:
+            print("TODO: Implement memory access for this address")
+            return 0x00
+        }
+    }
+
+    mutating func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case Self.ramMirrorsBegin ... Self.ramMirrorsEnd:
+            let vramAddress = Int(address & 0b0000_0111_1111_1111)
+            self.vram[vramAddress] = byte
+        case Self.ppuRegistersMirrorsBegin ... Self.ppuRegistersMirrorsEnd:
+            let ppuAddress = Int(address & 0b0010_0000_0000_0111)
+            fatalError("TODO! Implement PPU access!")
+        default:
+            print("TODO: Implement memory access for this address")
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new `Bus` struct which currently serves as an interface to a 2K RAM buffer. For the time being, only addresses from 0x0000 through 0x07ff are properly handled by `readByte()` and `writeByte()`. Because of this, we need to explicitly set the program counter of the CPU to 0x0600 inside its `reset()` method.