### PR TITLE
Implement undocumented instructions

### DIFF
--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -465,6 +465,15 @@ extension CPU {
         return true
     }
 
+    mutating func sax(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
+
+        self.writeByte(address: address, byte: self.accumulator & self.xRegister)
+
+        return false
+    }
+
     mutating func sbc(addressingMode: AddressingMode) -> Bool {
         let address = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
@@ -676,6 +685,8 @@ extension CPU {
                 self.rti()
             case .rts:
                 self.rts()
+            case .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX:
+                self.sax(addressingMode: opcode.addressingMode)
             case .sbcImmediate, .sbcZeroPage, .sbcZeroPageX, .sbcAbsolute, .sbcAbsoluteX, .sbcAbsoluteY, .sbcIndirectX, .sbcIndirectY:
                 self.sbc(addressingMode: opcode.addressingMode)
             case .sec:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -421,6 +421,16 @@ extension CPU {
         return false
     }
 
+    mutating func rla(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
+        let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
+        self.writeByte(address: address, byte: (value << 1) | oldCarry)
+        self.statusRegister[.carry] = (value >> 7) == 1
+
+        return self.and(addressingMode: addressingMode)
+    }
+
     mutating func rol(addressingMode: AddressingMode) -> Bool {
         if addressingMode == .accumulator {
             let carry = self.accumulator >> 7
@@ -486,8 +496,6 @@ extension CPU {
 
     mutating func sax(addressingMode: AddressingMode) -> Bool {
         let address = self.getAbsoluteAddress(addressingMode: addressingMode)
-        let value = self.readByte(address: address)
-
         self.writeByte(address: address, byte: self.accumulator & self.xRegister)
 
         return false
@@ -709,6 +717,8 @@ extension CPU {
                 self.pla()
             case .plp:
                 self.plp()
+            case .rlaAbsolute, .rlaAbsoluteX, .rlaAbsoluteY, .rlaZeroPage, .rlaZeroPageX, .rlaIndirectX, .rlaIndirectY:
+                self.rla(addressingMode: opcode.addressingMode)
             case .rolAccumulator, .rolZeroPage, .rolZeroPageX, .rolAbsolute, .rolAbsoluteX:
                 self.rol(addressingMode: opcode.addressingMode)
             case .rorAccumulator, .rorZeroPage, .rorZeroPageX, .rorAbsolute, .rorAbsoluteX:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -638,7 +638,12 @@ extension CPU {
                 self.ldy(addressingMode: opcode.addressingMode)
             case .lsrAccumulator, .lsrZeroPage, .lsrZeroPageX, .lsrAbsolute, .lsrAbsoluteX:
                 self.lsr(addressingMode: opcode.addressingMode)
-            case .nop:
+            case .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit6, .nopImplicit7,
+                    .nopImmediate1, .nopImmediate2, .nopImmediate3, .nopImmediate4, .nopImmediate5,
+                    .nopAbsolute,
+                    .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
+                    .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
+                    .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6:
                 self.nop()
             case .oraImmediate, .oraZeroPage, .oraZeroPageX, .oraAbsolute, .oraAbsoluteX, .oraAbsoluteY, .oraIndirectX, .oraIndirectY:
                 self.ora(addressingMode: opcode.addressingMode)

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -292,6 +292,17 @@ extension CPU {
         return false
     }
 
+    mutating func lax(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode);
+        let value = self.readByte(address: address);
+
+        self.accumulator = value
+        self.xRegister = value
+        self.updateZeroAndNegativeFlags(result: self.accumulator)
+
+        return false
+    }
+
     mutating func lda(addressingMode: AddressingMode) -> Bool {
         let address = self.getAbsoluteAddress(addressingMode: addressingMode);
         let value = self.readByte(address: address);
@@ -630,6 +641,8 @@ extension CPU {
                 self.jmp(addressingMode: opcode.addressingMode)
             case .jsr:
                 self.jsr()
+            case .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY:
+                self.lax(addressingMode: opcode.addressingMode)
             case .ldaImmediate, .ldaZeroPage, .ldaZeroPageX, .ldaAbsolute, .ldaAbsoluteX, .ldaAbsoluteY, .ldaIndirectX, .ldaIndirectY:
                 self.lda(addressingMode: opcode.addressingMode)
             case .ldxImmediate, .ldxZeroPage, .ldxZeroPageY, .ldxAbsolute, .ldxAbsoluteY:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -216,6 +216,18 @@ extension CPU {
         return false
     }
 
+    mutating func dcp(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
+
+        let newValue = value &- 1
+        self.writeByte(address: address, byte: newValue)
+        self.statusRegister[.carry] = newValue <= self.accumulator
+        self.updateZeroAndNegativeFlags(result: self.accumulator &- newValue)
+
+        return false
+    }
+
     mutating func dec(addressingMode: AddressingMode) -> Bool {
         let address = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
@@ -632,6 +644,8 @@ extension CPU {
                 self.cpx(addressingMode: opcode.addressingMode)
             case .cpyImmediate, .cpyZeroPage, .cpyAbsolute:
                 self.cpy(addressingMode: opcode.addressingMode)
+            case .dcpAbsolute, .dcpAbsoluteX, .dcpAbsoluteY, .dcpZeroPage, .dcpZeroPageX, .dcpIndirectX, .dcpIndirectY:
+                self.dcp(addressingMode: opcode.addressingMode)
             case .decZeroPage, .decZeroPageX, .decAbsolute, .decAbsoluteX:
                 self.dec(addressingMode: opcode.addressingMode)
             case .dex:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -471,6 +471,16 @@ extension CPU {
         return false
     }
 
+    mutating func rra(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
+        let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
+        self.writeByte(address: address, byte: (value >> 1) | oldCarry << 7)
+        self.statusRegister[.carry] = (value & 0b0000_0001) == 1
+
+        return self.adc(addressingMode: addressingMode)
+    }
+
     mutating func rti() -> Bool {
         self.statusRegister.rawValue = self.popStack()
         self.statusRegister[.break] = false
@@ -732,6 +742,8 @@ extension CPU {
                 self.rol(addressingMode: opcode.addressingMode)
             case .rorAccumulator, .rorZeroPage, .rorZeroPageX, .rorAbsolute, .rorAbsoluteX:
                 self.ror(addressingMode: opcode.addressingMode)
+            case .rraAbsolute, .rraAbsoluteX, .rraAbsoluteY, .rraZeroPage, .rraZeroPageX, .rraIndirectX, .rraIndirectY:
+                self.rra(addressingMode: opcode.addressingMode)
             case .rti:
                 self.rti()
             case .rts:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -687,7 +687,7 @@ extension CPU {
                 self.rts()
             case .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX:
                 self.sax(addressingMode: opcode.addressingMode)
-            case .sbcImmediate, .sbcZeroPage, .sbcZeroPageX, .sbcAbsolute, .sbcAbsoluteX, .sbcAbsoluteY, .sbcIndirectX, .sbcIndirectY:
+            case .sbcImmediate1, .sbcImmediate2, .sbcZeroPage, .sbcZeroPageX, .sbcAbsolute, .sbcAbsoluteX, .sbcAbsoluteY, .sbcIndirectX, .sbcIndirectY:
                 self.sbc(addressingMode: opcode.addressingMode)
             case .sec:
                 self.sec()

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -262,8 +262,8 @@ extension CPU {
     }
 
     mutating func inc(addressingMode: AddressingMode) -> Bool {
-        let address = self.getAbsoluteAddress(addressingMode: addressingMode);
-        let value = self.readByte(address: address);
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
         self.writeByte(address: address, byte: value &+ 1)
         self.updateZeroAndNegativeFlags(result: self.readByte(address: address))
 
@@ -275,6 +275,13 @@ extension CPU {
         self.updateZeroAndNegativeFlags(result: self.xRegister)
 
         return false
+    }
+
+    mutating func isb(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        self.writeByte(address: address, byte: self.readByte(address: address) &+ 1)
+
+        return self.sbc(addressingMode: addressingMode)
     }
 
     mutating func jmp(addressingMode: AddressingMode) -> Bool {
@@ -660,6 +667,8 @@ extension CPU {
                 self.inx()
             case .iny:
                 self.iny()
+            case .isbAbsolute, .isbAbsoluteX, .isbAbsoluteY, .isbZeroPage, .isbZeroPageX, .isbIndirectX, .isbIndirectY:
+                self.isb(addressingMode: opcode.addressingMode)
             case .jmpAbsolute, .jmpIndirect:
                 self.jmp(addressingMode: opcode.addressingMode)
             case .jsr:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -546,6 +546,15 @@ extension CPU {
         return self.ora(addressingMode: addressingMode)
     }
 
+    mutating func sre(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let value = self.readByte(address: address)
+        self.writeByte(address: address, byte: value >> 1)
+        self.statusRegister[.carry] = (value & 0b0000_0001) == 1
+
+        return self.eor(addressingMode: addressingMode)
+    }
+
     mutating func sta(addressingMode: AddressingMode) -> Bool {
         let address = self.getAbsoluteAddress(addressingMode: addressingMode)
         self.writeByte(address: address, byte: self.accumulator)
@@ -739,6 +748,8 @@ extension CPU {
                 self.sei()
             case .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:
                 self.slo(addressingMode: opcode.addressingMode)
+            case .sreAbsolute, .sreAbsoluteX, .sreAbsoluteY, .sreZeroPage, .sreZeroPageX, .sreIndirectX, .sreIndirectY:
+                self.sre(addressingMode: opcode.addressingMode)
             case .staZeroPage, .staZeroPageX, .staAbsolute, .staAbsoluteX, .staAbsoluteY, .staIndirectX, .staIndirectY:
                 self.sta(addressingMode: opcode.addressingMode)
             case .stxZeroPage, .stxZeroPageY, .stxAbsolute:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -529,9 +529,18 @@ extension CPU {
         return false
     }
 
+    mutating func slo(addressingMode: AddressingMode) -> Bool {
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        let oldValue = self.readByte(address: address)
+        self.writeByte(address: address, byte: oldValue << 1)
+        self.statusRegister[.carry] = (oldValue >> 7) == 1
+
+        return self.ora(addressingMode: addressingMode)
+    }
+
     mutating func sta(addressingMode: AddressingMode) -> Bool {
-        let address = self.getAbsoluteAddress(addressingMode: addressingMode);
-        self.writeByte(address: address, byte: self.accumulator);
+        let address = self.getAbsoluteAddress(addressingMode: addressingMode)
+        self.writeByte(address: address, byte: self.accumulator)
 
         return false
     }
@@ -718,6 +727,8 @@ extension CPU {
                 self.sed()
             case .sei:
                 self.sei()
+            case .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:
+                self.slo(addressingMode: opcode.addressingMode)
             case .staZeroPage, .staZeroPageX, .staAbsolute, .staAbsoluteX, .staAbsoluteY, .staIndirectX, .staIndirectY:
                 self.sta(addressingMode: opcode.addressingMode)
             case .stxZeroPage, .stxZeroPageY, .stxAbsolute:

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -192,6 +192,14 @@ enum Opcode: UInt8 {
     case pla = 0x68
     case plp = 0x28
 
+    case rlaAbsolute = 0x2F
+    case rlaAbsoluteX = 0x3F
+    case rlaAbsoluteY = 0x3B
+    case rlaZeroPage = 0x27
+    case rlaZeroPageX = 0x37
+    case rlaIndirectX = 0x23
+    case rlaIndirectY = 0x33
+
     case rolAccumulator = 0x2A
     case rolZeroPage = 0x26
     case rolZeroPageX = 0x36
@@ -446,6 +454,14 @@ extension Opcode {
         case .php: .implicit
         case .pla: .implicit
         case .plp: .implicit
+
+        case .rlaAbsolute: .absolute
+        case .rlaAbsoluteX: .absoluteX
+        case .rlaAbsoluteY: .absoluteY
+        case .rlaZeroPage: .zeroPage
+        case .rlaZeroPageX: .zeroPageX
+        case .rlaIndirectX: .indirectX
+        case .rlaIndirectY: .indirectY
 
         case .rolAccumulator: .accumulator
         case .rolZeroPage: .zeroPage
@@ -702,6 +718,14 @@ extension Opcode {
         case .pla: 1
         case .plp: 1
 
+        case .rlaAbsolute: 3
+        case .rlaAbsoluteX: 3
+        case .rlaAbsoluteY: 3
+        case .rlaZeroPage: 2
+        case .rlaZeroPageX: 2
+        case .rlaIndirectX: 2
+        case .rlaIndirectY: 2
+
         case .rolAccumulator: 1
         case .rolZeroPage: 2
         case .rolZeroPageX: 2
@@ -790,6 +814,7 @@ extension Opcode {
                 .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
                 .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
+                .rlaAbsolute, .rlaAbsoluteX, .rlaAbsoluteY, .rlaZeroPage, .rlaZeroPageX, .rlaIndirectX, .rlaIndirectY,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
                 .sbcImmediate2,
                 .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -196,7 +196,8 @@ enum Opcode: UInt8 {
     case saxZeroPageY = 0x97
     case saxIndirectX = 0x83
 
-    case sbcImmediate = 0xE9
+    case sbcImmediate1 = 0xE9
+    case sbcImmediate2 = 0xEB
     case sbcZeroPage = 0xE5
     case sbcZeroPageX = 0xF5
     case sbcAbsolute = 0xED
@@ -426,7 +427,8 @@ extension Opcode {
         case .saxZeroPageY: .zeroPageY
         case .saxIndirectX: .indirectX
 
-        case .sbcImmediate: .immediate
+        case .sbcImmediate1: .immediate
+        case .sbcImmediate2: .immediate
         case .sbcZeroPage: .zeroPage
         case .sbcZeroPageX: .zeroPageX
         case .sbcAbsolute: .absolute
@@ -656,7 +658,8 @@ extension Opcode {
         case .saxAbsolute: 3
         case .saxIndirectX: 2
 
-        case .sbcImmediate: 2
+        case .sbcImmediate1: 2
+        case .sbcImmediate2: 2
         case .sbcZeroPage: 2
         case .sbcZeroPageX: 2
         case .sbcAbsolute: 3
@@ -706,14 +709,15 @@ extension Opcode {
 extension Opcode {
     var isDocumented: Bool {
         switch self {
-        case .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
+        case .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
+                .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
                 .nopImmediate1, .nopImmediate2, .nopImmediate3, .nopImmediate4, .nopImmediate5,
                 .nopAbsolute,
                 .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
                 .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
-                .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
-                .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX:
+                .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
+                .sbcImmediate2:
             return false
         default:
             return true

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -191,6 +191,11 @@ enum Opcode: UInt8 {
     case rti = 0x40
     case rts = 0x60
 
+    case saxAbsolute = 0x8F
+    case saxZeroPage = 0x87
+    case saxZeroPageY = 0x97
+    case saxIndirectX = 0x83
+
     case sbcImmediate = 0xE9
     case sbcZeroPage = 0xE5
     case sbcZeroPageX = 0xF5
@@ -415,6 +420,11 @@ extension Opcode {
 
         case .rti: .implicit
         case .rts: .implicit
+
+        case .saxAbsolute: .absolute
+        case .saxZeroPage: .zeroPage
+        case .saxZeroPageY: .zeroPageY
+        case .saxIndirectX: .indirectX
 
         case .sbcImmediate: .immediate
         case .sbcZeroPage: .zeroPage
@@ -641,6 +651,11 @@ extension Opcode {
         case .rti: 1
         case .rts: 1
 
+        case .saxZeroPage: 2
+        case .saxZeroPageY: 2
+        case .saxAbsolute: 3
+        case .saxIndirectX: 2
+
         case .sbcImmediate: 2
         case .sbcZeroPage: 2
         case .sbcZeroPageX: 2
@@ -697,7 +712,8 @@ extension Opcode {
                 .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
                 .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
-                .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY:
+                .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
+                .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX:
             return false
         default:
             return true

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -98,6 +98,14 @@ enum Opcode: UInt8 {
 
     case jsr = 0x20
 
+    case laxImmediate = 0xAB
+    case laxZeroPage = 0xA7
+    case laxZeroPageY = 0xB7
+    case laxAbsolute = 0xAF
+    case laxAbsoluteY = 0xBF
+    case laxIndirectX = 0xA3
+    case laxIndirectY = 0xB3
+
     case ldaImmediate = 0xA9
     case ldaZeroPage = 0xA5
     case ldaZeroPageX = 0xB5
@@ -314,6 +322,14 @@ extension Opcode {
         case .jmpIndirect: .indirect
 
         case .jsr: .absolute
+
+        case .laxImmediate: .immediate
+        case .laxZeroPage: .zeroPage
+        case .laxZeroPageY: .zeroPageY
+        case .laxAbsolute: .absolute
+        case .laxAbsoluteY: .absoluteY
+        case .laxIndirectX: .indirectX
+        case .laxIndirectY: .indirectY
 
         case .ldaImmediate: .immediate
         case .ldaZeroPage: .zeroPage
@@ -532,6 +548,14 @@ extension Opcode {
 
         case .jsr: 3
 
+        case .laxImmediate: 2
+        case .laxZeroPage: 2
+        case .laxZeroPageY: 2
+        case .laxAbsolute: 3
+        case .laxAbsoluteY: 3
+        case .laxIndirectX: 2
+        case .laxIndirectY: 2
+
         case .ldaImmediate: 2
         case .ldaZeroPage: 2
         case .ldaZeroPageX: 2
@@ -672,7 +696,8 @@ extension Opcode {
                 .nopAbsolute,
                 .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
-                .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6:
+                .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
+                .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY:
             return false
         default:
             return true

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -242,6 +242,14 @@ enum Opcode: UInt8 {
     case sloIndirectX = 0x03
     case sloIndirectY = 0x13
 
+    case sreAbsolute = 0x4F
+    case sreAbsoluteX = 0x5F
+    case sreAbsoluteY = 0x5B
+    case sreZeroPage = 0x47
+    case sreZeroPageX = 0x57
+    case sreIndirectX = 0x43
+    case sreIndirectY = 0x53
+
     case staZeroPage = 0x85
     case staZeroPageX = 0x95
     case staAbsolute = 0x8D
@@ -504,6 +512,14 @@ extension Opcode {
         case .sloZeroPageX: .zeroPageX
         case .sloIndirectX: .indirectX
         case .sloIndirectY: .indirectY
+
+        case .sreAbsolute: .absolute
+        case .sreAbsoluteX: .absoluteX
+        case .sreAbsoluteY: .absoluteY
+        case .sreZeroPage: .zeroPage
+        case .sreZeroPageX: .zeroPageX
+        case .sreIndirectX: .indirectX
+        case .sreIndirectY: .indirectY
 
         case .staZeroPage: .zeroPage
         case .staZeroPageX: .zeroPageX
@@ -768,6 +784,14 @@ extension Opcode {
         case .sloIndirectX: 2
         case .sloIndirectY: 2
 
+        case .sreAbsolute: 3
+        case .sreAbsoluteX: 3
+        case .sreAbsoluteY: 3
+        case .sreZeroPage: 2
+        case .sreZeroPageX: 2
+        case .sreIndirectX: 2
+        case .sreIndirectY: 2
+
         case .staZeroPage: 2
         case .staZeroPageX: 2
         case .staAbsolute: 3
@@ -817,7 +841,8 @@ extension Opcode {
                 .rlaAbsolute, .rlaAbsoluteX, .rlaAbsoluteY, .rlaZeroPage, .rlaZeroPageX, .rlaIndirectX, .rlaIndirectY,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
                 .sbcImmediate2,
-                .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:
+                .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY,
+                .sreAbsolute, .sreAbsoluteX, .sreAbsoluteY, .sreZeroPage, .sreZeroPageX, .sreIndirectX, .sreIndirectY:
             return false
         default:
             return true

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -226,6 +226,14 @@ enum Opcode: UInt8 {
     case sed = 0xF8
     case sei = 0x78
 
+    case sloAbsolute = 0x0F
+    case sloAbsoluteX = 0x1F
+    case sloAbsoluteY = 0x1B
+    case sloZeroPage = 0x07
+    case sloZeroPageX = 0x17
+    case sloIndirectX = 0x03
+    case sloIndirectY = 0x13
+
     case staZeroPage = 0x85
     case staZeroPageX = 0x95
     case staAbsolute = 0x8D
@@ -472,6 +480,14 @@ extension Opcode {
         case .sec: .implicit
         case .sed: .implicit
         case .sei: .implicit
+
+        case .sloAbsolute: .absolute
+        case .sloAbsoluteX: .absoluteX
+        case .sloAbsoluteY: .absoluteY
+        case .sloZeroPage: .zeroPage
+        case .sloZeroPageX: .zeroPageX
+        case .sloIndirectX: .indirectX
+        case .sloIndirectY: .indirectY
 
         case .staZeroPage: .zeroPage
         case .staZeroPageX: .zeroPageX
@@ -720,6 +736,14 @@ extension Opcode {
         case .sed: 1
         case .sei: 1
 
+        case .sloAbsolute: 3
+        case .sloAbsoluteX: 3
+        case .sloAbsoluteY: 3
+        case .sloZeroPage: 2
+        case .sloZeroPageX: 2
+        case .sloIndirectX: 2
+        case .sloIndirectY: 2
+
         case .staZeroPage: 2
         case .staZeroPageX: 2
         case .staAbsolute: 3
@@ -767,7 +791,8 @@ extension Opcode {
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
                 .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
-                .sbcImmediate2:
+                .sbcImmediate2,
+                .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:
             return false
         default:
             return true

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -101,6 +101,14 @@ enum Opcode: UInt8 {
     case inx = 0xE8
     case iny = 0xC8
 
+    case isbAbsolute = 0xEF
+    case isbAbsoluteX = 0xFF
+    case isbAbsoluteY = 0xFB
+    case isbZeroPage = 0xE7
+    case isbZeroPageX = 0xF7
+    case isbIndirectX = 0xE3
+    case isbIndirectY = 0xF3
+
     case jmpAbsolute = 0x4C
     case jmpIndirect = 0x6C
 
@@ -339,6 +347,14 @@ extension Opcode {
 
         case .inx: .implicit
         case .iny: .implicit
+
+        case .isbAbsolute: .absolute
+        case .isbAbsoluteX: .absoluteX
+        case .isbAbsoluteY: .absoluteY
+        case .isbZeroPage: .zeroPage
+        case .isbZeroPageX: .zeroPageX
+        case .isbIndirectX: .indirectX
+        case .isbIndirectY: .indirectY
 
         case .jmpAbsolute: .absolute
         case .jmpIndirect: .indirect
@@ -579,6 +595,14 @@ extension Opcode {
         case .inx: 1
         case .iny: 1
 
+        case .isbAbsolute: 3
+        case .isbAbsoluteX: 3
+        case .isbAbsoluteY: 3
+        case .isbZeroPage: 2
+        case .isbZeroPageX: 2
+        case .isbIndirectX: 2
+        case .isbIndirectY: 2
+
         case .jmpAbsolute: 3
         case .jmpIndirect: 3
 
@@ -734,6 +758,7 @@ extension Opcode {
     var isDocumented: Bool {
         switch self {
         case .dcpAbsolute, .dcpAbsoluteX, .dcpAbsoluteY, .dcpZeroPage, .dcpZeroPageX, .dcpIndirectX, .dcpIndirectY,
+                .isbAbsolute, .isbAbsoluteX, .isbAbsoluteY, .isbZeroPage, .isbZeroPageX, .isbIndirectX, .isbIndirectY,
                 .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
                 .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
                 .nopImmediate1, .nopImmediate2, .nopImmediate3, .nopImmediate4, .nopImmediate5,

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -68,6 +68,14 @@ enum Opcode: UInt8 {
     case cpyZeroPage = 0xC4
     case cpyAbsolute = 0xCC
 
+    case dcpAbsolute = 0xCF
+    case dcpAbsoluteX = 0xDF
+    case dcpAbsoluteY = 0xDB
+    case dcpZeroPage = 0xC7
+    case dcpZeroPageX = 0xD7
+    case dcpIndirectX = 0xC3
+    case dcpIndirectY = 0xD3
+
     case decZeroPage = 0xC6
     case decZeroPageX = 0xD6
     case decAbsolute = 0xCE
@@ -298,6 +306,14 @@ extension Opcode {
         case .cpyImmediate: .immediate
         case .cpyZeroPage: .zeroPage
         case .cpyAbsolute: .absolute
+
+        case .dcpAbsolute: .absolute
+        case .dcpAbsoluteX: .absoluteX
+        case .dcpAbsoluteY: .absoluteY
+        case .dcpZeroPage: .zeroPage
+        case .dcpZeroPageX: .zeroPageX
+        case .dcpIndirectX: .indirectX
+        case .dcpIndirectY: .indirectY
 
         case .decZeroPage: .zeroPage
         case .decZeroPageX: .zeroPageX
@@ -530,6 +546,14 @@ extension Opcode {
         case .cpyZeroPage: 2
         case .cpyAbsolute: 3
 
+        case .dcpAbsolute: 3
+        case .dcpAbsoluteX: 3
+        case .dcpAbsoluteY: 3
+        case .dcpZeroPage: 2
+        case .dcpZeroPageX: 2
+        case .dcpIndirectX: 2
+        case .dcpIndirectY: 2
+
         case .decZeroPage: 2
         case .decZeroPageX: 2
         case .decAbsolute: 3
@@ -709,7 +733,8 @@ extension Opcode {
 extension Opcode {
     var isDocumented: Bool {
         switch self {
-        case .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
+        case .dcpAbsolute, .dcpAbsoluteX, .dcpAbsoluteY, .dcpZeroPage, .dcpZeroPageX, .dcpIndirectX, .dcpIndirectY,
+                .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
                 .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
                 .nopImmediate1, .nopImmediate2, .nopImmediate3, .nopImmediate4, .nopImmediate5,
                 .nopAbsolute,

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -125,7 +125,34 @@ enum Opcode: UInt8 {
     case lsrAbsolute = 0x4E
     case lsrAbsoluteX = 0x5E
 
-    case nop = 0xEA
+    case nopImplicit1 = 0x1A
+    case nopImplicit2 = 0x3A
+    case nopImplicit3 = 0x5A
+    case nopImplicit4 = 0x7A
+    case nopImplicit5 = 0xDA
+    case nopImplicit6 = 0xEA
+    case nopImplicit7 = 0xFA
+    case nopImmediate1 = 0x80
+    case nopImmediate2 = 0x82
+    case nopImmediate3 = 0x89
+    case nopImmediate4 = 0xC2
+    case nopImmediate5 = 0xE2
+    case nopAbsolute = 0x0C
+    case nopAbsoluteX1 = 0x1C
+    case nopAbsoluteX2 = 0x3C
+    case nopAbsoluteX3 = 0x5C
+    case nopAbsoluteX4 = 0x7C
+    case nopAbsoluteX5 = 0xDC
+    case nopAbsoluteX6 = 0xFC
+    case nopZeroPage1 = 0x04
+    case nopZeroPage2 = 0x44
+    case nopZeroPage3 = 0x64
+    case nopZeroPageX1 = 0x14
+    case nopZeroPageX2 = 0x34
+    case nopZeroPageX3 = 0x54
+    case nopZeroPageX4 = 0x74
+    case nopZeroPageX5 = 0xD4
+    case nopZeroPageX6 = 0xF4
 
     case oraImmediate = 0x09
     case oraZeroPage = 0x05
@@ -315,7 +342,34 @@ extension Opcode {
         case .lsrAbsolute: .absolute
         case .lsrAbsoluteX: .absoluteX
 
-        case .nop: .implicit
+        case .nopImplicit1: .implicit
+        case .nopImplicit2: .implicit
+        case .nopImplicit3: .implicit
+        case .nopImplicit4: .implicit
+        case .nopImplicit5: .implicit
+        case .nopImplicit6: .implicit
+        case .nopImplicit7: .implicit
+        case .nopImmediate1: .immediate
+        case .nopImmediate2: .immediate
+        case .nopImmediate3: .immediate
+        case .nopImmediate4: .immediate
+        case .nopImmediate5: .immediate
+        case .nopAbsolute: .absolute
+        case .nopAbsoluteX1: .absoluteX
+        case .nopAbsoluteX2: .absoluteX
+        case .nopAbsoluteX3: .absoluteX
+        case .nopAbsoluteX4: .absoluteX
+        case .nopAbsoluteX5: .absoluteX
+        case .nopAbsoluteX6: .absoluteX
+        case .nopZeroPage1: .zeroPage
+        case .nopZeroPage2: .zeroPage
+        case .nopZeroPage3: .zeroPage
+        case .nopZeroPageX1: .zeroPageX
+        case .nopZeroPageX2: .zeroPageX
+        case .nopZeroPageX3: .zeroPageX
+        case .nopZeroPageX4: .zeroPageX
+        case .nopZeroPageX5: .zeroPageX
+        case .nopZeroPageX6: .zeroPageX
 
         case .oraImmediate: .immediate
         case .oraZeroPage: .zeroPage
@@ -505,7 +559,34 @@ extension Opcode {
         case .lsrAbsolute: 3
         case .lsrAbsoluteX: 3
 
-        case .nop: 1
+        case .nopImplicit1: 1
+        case .nopImplicit2: 1
+        case .nopImplicit3: 1
+        case .nopImplicit4: 1
+        case .nopImplicit5: 1
+        case .nopImplicit6: 1
+        case .nopImplicit7: 1
+        case .nopImmediate1: 2
+        case .nopImmediate2: 2
+        case .nopImmediate3: 2
+        case .nopImmediate4: 2
+        case .nopImmediate5: 2
+        case .nopAbsolute: 3
+        case .nopAbsoluteX1: 3
+        case .nopAbsoluteX2: 3
+        case .nopAbsoluteX3: 3
+        case .nopAbsoluteX4: 3
+        case .nopAbsoluteX5: 3
+        case .nopAbsoluteX6: 3
+        case .nopZeroPage1: 2
+        case .nopZeroPage2: 2
+        case .nopZeroPage3: 2
+        case .nopZeroPageX1: 2
+        case .nopZeroPageX2: 2
+        case .nopZeroPageX3: 2
+        case .nopZeroPageX4: 2
+        case .nopZeroPageX5: 2
+        case .nopZeroPageX6: 2
 
         case .oraImmediate: 2
         case .oraZeroPage: 2
@@ -580,5 +661,21 @@ extension Opcode {
         let opcodeString = String(describing: self)
         let endIndex = opcodeString.index(opcodeString.startIndex, offsetBy: 2)
         return opcodeString[opcodeString.startIndex ... endIndex].uppercased()
+    }
+}
+
+extension Opcode {
+    var isDocumented: Bool {
+        switch self {
+        case .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
+                .nopImmediate1, .nopImmediate2, .nopImmediate3, .nopImmediate4, .nopImmediate5,
+                .nopAbsolute,
+                .nopAbsoluteX1, .nopAbsoluteX2, .nopAbsoluteX3, .nopAbsoluteX4, .nopAbsoluteX5, .nopAbsoluteX6,
+                .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
+                .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6:
+            return false
+        default:
+            return true
+        }
     }
 }

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -212,6 +212,14 @@ enum Opcode: UInt8 {
     case rorAbsolute = 0x6E
     case rorAbsoluteX = 0x7E
 
+    case rraAbsolute = 0x6F
+    case rraAbsoluteX = 0x7F
+    case rraAbsoluteY = 0x7B
+    case rraZeroPage = 0x67
+    case rraZeroPageX = 0x77
+    case rraIndirectX = 0x63
+    case rraIndirectY = 0x73
+
     case rti = 0x40
     case rts = 0x60
 
@@ -482,6 +490,14 @@ extension Opcode {
         case .rorZeroPageX: .zeroPageX
         case .rorAbsolute: .absolute
         case .rorAbsoluteX: .absoluteX
+
+        case .rraAbsolute: .absolute
+        case .rraAbsoluteX: .absoluteX
+        case .rraAbsoluteY: .absoluteY
+        case .rraZeroPage: .zeroPage
+        case .rraZeroPageX: .zeroPageX
+        case .rraIndirectX: .indirectX
+        case .rraIndirectY: .indirectY
 
         case .rti: .implicit
         case .rts: .implicit
@@ -754,6 +770,14 @@ extension Opcode {
         case .rorAbsolute: 3
         case .rorAbsoluteX: 3
 
+        case .rraAbsolute: 3
+        case .rraAbsoluteX: 3
+        case .rraAbsoluteY: 3
+        case .rraZeroPage: 2
+        case .rraZeroPageX: 2
+        case .rraIndirectX: 2
+        case .rraIndirectY: 2
+
         case .rti: 1
         case .rts: 1
 
@@ -839,6 +863,7 @@ extension Opcode {
                 .nopZeroPage1, .nopZeroPage2, .nopZeroPage3,
                 .nopZeroPageX1, .nopZeroPageX2, .nopZeroPageX3, .nopZeroPageX4, .nopZeroPageX5, .nopZeroPageX6,
                 .rlaAbsolute, .rlaAbsoluteX, .rlaAbsoluteY, .rlaZeroPage, .rlaZeroPageX, .rlaIndirectX, .rlaIndirectY,
+                .rraAbsolute, .rraAbsoluteX, .rraAbsoluteY, .rraZeroPage, .rraZeroPageX, .rraIndirectX, .rraIndirectY,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
                 .sbcImmediate2,
                 .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY,


### PR DESCRIPTION
This is a fairly straightforward PR: it implements the remaining opcodes which are all undocumented. Things of note:

* I needed to introduce a new computed property for `Opcode`, namely `isDocumented`, so that the tracer can display an asterisk for lines associated with an undocumented instruction.
* A lot of the new instructions are partially implemented in terms of other documented instructions. Although this reduces code duplication, this may become a problem in the future when we need to compute cycles... but for now I think this approach is ok.
* The tracer had a slight bug for outputting lines for instructions using the `.relative` addressing mode, and in order to address it, I basically copied some of the code in `getAbsoluteAddress()`. I don't really like this but I don't expect `getAbsoluteAddress()` to evolve and thus potentially get out of sync with the tracer.