### PR TITLE
Implement game input

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		87184D032C67D9DD0003D090 /* CPU+withoutMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87184D022C67D9DD0003D090 /* CPU+withoutMutation.swift */; };
 		87184D052C7028F10003D090 /* PPUStatusRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87184D042C7028F10003D090 /* PPUStatusRegister.swift */; };
 		87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87184D092C7511F90003D090 /* MaskRegister.swift */; };
 		87184D0C2C7522B80003D090 /* ScrollRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87184D0B2C7522B80003D090 /* ScrollRegister.swift */; };
@@ -45,6 +44,7 @@
 		8763D06A2C39B719006C1B4F /* RomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0692C39B719006C1B4F /* RomTests.swift */; };
 		8763D06C2C39E528006C1B4F /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06B2C39E528006C1B4F /* Screen.swift */; };
 		8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06D2C3A340C006C1B4F /* Tracing.swift */; };
+		877E970B2C7E4716007513B5 /* Joypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E970A2C7E4716007513B5 /* Joypad.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,7 +79,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		87184D022C67D9DD0003D090 /* CPU+withoutMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CPU+withoutMutation.swift"; sourceTree = "<group>"; };
 		87184D042C7028F10003D090 /* PPUStatusRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPUStatusRegister.swift; sourceTree = "<group>"; };
 		87184D092C7511F90003D090 /* MaskRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskRegister.swift; sourceTree = "<group>"; };
 		87184D0B2C7522B80003D090 /* ScrollRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollRegister.swift; sourceTree = "<group>"; };
@@ -116,6 +115,7 @@
 		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
 		8763D06B2C39E528006C1B4F /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		8763D06D2C3A340C006C1B4F /* Tracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracing.swift; sourceTree = "<group>"; };
+		877E970A2C7E4716007513B5 /* Joypad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joypad.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +208,7 @@
 				8719320F2C372F6900A73C22 /* Bus.swift */,
 				871F62352C65631F00132962 /* ControllerRegister.swift */,
 				8744B1902C1CC0C4001B44B5 /* CPU.swift */,
+				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 				87184D092C7511F90003D090 /* MaskRegister.swift */,
 				871932112C37985700A73C22 /* Mirroring.swift */,
@@ -410,6 +411,7 @@
 				871932142C3798B400A73C22 /* Rom.swift in Sources */,
 				87184D0C2C7522B80003D090 /* ScrollRegister.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
+				877E970B2C7E4716007513B5 /* Joypad.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -15,6 +15,7 @@ public struct Bus {
     var vram: [UInt8]
     var prgRom: [UInt8]
     var cycles: Int
+    var joypad: Joypad
 
     public init(rom: Rom) {
         let ppu = PPU(chrRom: rom.chrRom, mirroring: rom.mirroring)
@@ -23,6 +24,7 @@ public struct Bus {
         self.vram = [UInt8](repeating: 0x00, count: 2048)
         self.prgRom = rom.prgRom
         self.cycles = 0
+        self.joypad = Joypad()
     }
 }
 
@@ -55,6 +57,8 @@ extension Bus {
         case 0x2008...Self.ppuRegistersMirrorsEnd:
             let mirrorDownAddress = address & 0b0010_0000_0000_0111
             return self.readByteWithoutMutating(address: mirrorDownAddress)
+        case 0x4016:
+            return self.joypad.readByteWithoutMutating()
         case 0x8000 ... 0xFFFF:
             return self.readPrgRom(address: address)
         default:
@@ -74,6 +78,8 @@ extension Bus {
         case 0x2008...Self.ppuRegistersMirrorsEnd:
             let mirrorDownAddress = address & 0b0010_0000_0000_0111
             return self.readByte(address: mirrorDownAddress)
+        case 0x4016:
+            return self.joypad.readByte()
         default:
             return self.readByteWithoutMutating(address: address)
         }
@@ -109,6 +115,8 @@ extension Bus {
                 buffer[index] = self.readByte(address: baseAddress + UInt16(index))
             }
             self.ppu.writeOamBuffer(buffer: buffer)
+        case 0x4016:
+            self.joypad.writeByte(byte: byte)
         case 0x8000 ... 0xFFFF:
             fatalError("Attempt to write to cartridge ROM space")
         default:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -1014,12 +1014,8 @@ extension CPU {
 }
 
 extension CPU {
-    mutating public func buttonDown(button: JoypadButton) {
-        self.bus.joypad.updateButtonStatus(button: button, status: true)
-    }
-
-    mutating public func buttonUp(button: JoypadButton) {
-        self.bus.joypad.updateButtonStatus(button: button, status: false)
+    mutating public func handleButton(button: JoypadButton, status: Bool) {
+        self.bus.joypad.updateButtonStatus(button: button, status: status)
     }
 }
 

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -1015,7 +1015,11 @@ extension CPU {
 
 extension CPU {
     mutating public func buttonDown(button: JoypadButton) {
-        self.writeByte(address: 0x00FF, byte: button.rawValue)
+        self.bus.joypad.updateButtonStatus(button: button, status: true)
+    }
+
+    mutating public func buttonUp(button: JoypadButton) {
+        self.bus.joypad.updateButtonStatus(button: button, status: false)
     }
 }
 

--- a/happiNESs/Joypad.swift
+++ b/happiNESs/Joypad.swift
@@ -1,0 +1,62 @@
+//
+//  Joypad.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 8/27/24.
+//
+
+import SwiftUI
+
+public struct Joypad {
+    public static let keyMappings: [Character : JoypadButton] = [
+        KeyEquivalent.upArrow.character : .up,
+        KeyEquivalent.downArrow.character : .down,
+        KeyEquivalent.leftArrow.character : .left,
+        KeyEquivalent.rightArrow.character : .right,
+        KeyEquivalent.space.character : .select,
+        KeyEquivalent.return.character : .start,
+        "a" : .buttonA,
+        "s" : .buttonB,
+    ]
+
+    public var strobe: Bool
+    public var buttonIndex: Int
+    public var joypadButton: JoypadButton
+
+    init() {
+        self.strobe = false
+        self.buttonIndex = 0
+        self.joypadButton = JoypadButton()
+    }
+}
+
+extension Joypad {
+    public func readByteWithoutMutating() -> UInt8 {
+        return (self.joypadButton.rawValue & (1 << self.buttonIndex)) >> self.buttonIndex
+    }
+
+    mutating public func readByte() -> UInt8 {
+        if self.buttonIndex > 7 {
+            return 1
+        }
+
+        let result = self.readByteWithoutMutating()
+        if !self.strobe && self.buttonIndex <= 7 {
+            self.buttonIndex += 1
+        }
+
+        return result
+    }
+
+    mutating public func writeByte(byte: UInt8) {
+        self.strobe = (byte & 0b0000_0001) == 1
+
+        if self.strobe {
+            self.buttonIndex = 0
+        }
+    }
+
+    mutating public func updateButtonStatus(button: JoypadButton, status: Bool) {
+        self.joypadButton[button] = status
+    }
+}

--- a/happiNESs/Joypad.swift
+++ b/happiNESs/Joypad.swift
@@ -5,20 +5,7 @@
 //  Created by Danielle Kefford on 8/27/24.
 //
 
-import SwiftUI
-
 public struct Joypad {
-    public static let keyMappings: [Character : JoypadButton] = [
-        KeyEquivalent.upArrow.character : .up,
-        KeyEquivalent.downArrow.character : .down,
-        KeyEquivalent.leftArrow.character : .left,
-        KeyEquivalent.rightArrow.character : .right,
-        KeyEquivalent.space.character : .select,
-        KeyEquivalent.return.character : .start,
-        "a" : .buttonA,
-        "s" : .buttonB,
-    ]
-
     public var strobe: Bool
     public var buttonIndex: Int
     public var joypadButton: JoypadButton

--- a/happiNESs/JoypadButton.swift
+++ b/happiNESs/JoypadButton.swift
@@ -5,9 +5,46 @@
 //  Created by Danielle Kefford on 6/29/24.
 //
 
-public enum JoypadButton: UInt8 {
-    case up = 0x77
-    case down = 0x73
-    case left = 0x61
-    case right = 0x64
+public struct JoypadButton: OptionSet {
+    public var rawValue: UInt8
+
+    public init(rawValue: UInt8 = 0b0000_0000) {
+        self.rawValue = rawValue
+    }
+
+    //  7 6 5 4 3 2 1 0
+    //  R L D U S L B A
+    //  | | | | | | | +--- Button A
+    //  | | | | | | +----- Button B
+    //  | | | | | +------- Select
+    //  | | | | +--------- Start
+    //  | | | +----------- Up
+    //  | | +------------- Down
+    //  | +--------------- Left
+    //  +----------------- Right
+    public static let buttonA = Self(rawValue: 1 << 0)
+    public static let buttonB = Self(rawValue: 1 << 1)
+    public static let select = Self(rawValue: 1 << 2)
+    public static let start = Self(rawValue: 1 << 3)
+    public static let up = Self(rawValue: 1 << 4)
+    public static let down = Self(rawValue: 1 << 5)
+    public static let left = Self(rawValue: 1 << 6)
+    public static let right = Self(rawValue: 1 << 7)
+
+    subscript (_ flags: Self) -> Bool {
+        get {
+            self.isSuperset(of: flags)
+        }
+        set {
+            if newValue {
+                self.insert(flags)
+            } else {
+                self.remove(flags)
+            }
+        }
+    }
+
+    mutating func reset() {
+        self.rawValue = 0b0000_0000
+    }
 }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -56,20 +56,21 @@ enum NESError: Error {
         cpu.updateScreenBuffer(&self.screenBuffer)
     }
 
-    func keyDown(_ press: KeyPress) -> Bool {
-        switch press.key {
-        case .upArrow:
-            cpu.buttonDown(button: .up)
-        case .downArrow:
-            cpu.buttonDown(button: .down)
-        case .leftArrow:
-            cpu.buttonDown(button: .left)
-        case .rightArrow:
-            cpu.buttonDown(button: .right)
-        default:
-            return false
+    func keyDown(_ keyPress: KeyPress) -> Bool {
+        if let button = Joypad.keyMappings[keyPress.key.character] {
+            cpu.buttonDown(button: button)
+            return true
         }
 
-        return true
+        return false
+    }
+
+    func keyUp(_ keyPress: KeyPress) -> Bool {
+        if let button = Joypad.keyMappings[keyPress.key.character] {
+            cpu.buttonUp(button: button)
+            return true
+        }
+
+        return false
     }
 }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -17,6 +17,17 @@ enum NESError: Error {
 @Observable @MainActor class Console {
     static let frameRate = 60
 
+    public static let keyMappings: [KeyEquivalent : JoypadButton] = [
+        .upArrow : .up,
+        .downArrow : .down,
+        .leftArrow : .left,
+        .rightArrow : .right,
+        .space : .select,
+        .return : .start,
+        KeyEquivalent("a") : .buttonA,
+        KeyEquivalent("s") : .buttonB,
+    ]
+
     var displayTimer: Timer!
 
     // NOTA BENE: We don't want the screen updated every single time something inside
@@ -56,21 +67,12 @@ enum NESError: Error {
         cpu.updateScreenBuffer(&self.screenBuffer)
     }
 
-    func keyDown(_ keyPress: KeyPress) -> Bool {
-        if let button = Joypad.keyMappings[keyPress.key.character] {
-            cpu.buttonDown(button: button)
-            return true
+    func handleKey(_ keyPress: KeyPress) -> Bool {
+        guard let button = Self.keyMappings[keyPress.key] else {
+            return false
         }
 
-        return false
-    }
-
-    func keyUp(_ keyPress: KeyPress) -> Bool {
-        if let button = Joypad.keyMappings[keyPress.key.character] {
-            cpu.buttonUp(button: button)
-            return true
-        }
-
-        return false
+        cpu.handleButton(button: button, status: keyPress.phase != .up)
+        return true
     }
 }

--- a/happiNESsApp/ContentView.swift
+++ b/happiNESsApp/ContentView.swift
@@ -31,8 +31,15 @@ struct ContentView: View {
         .onAppear {
             focused = true
         }
-        .onKeyPress(phases: [.down]) { keyPress in
-            console.keyDown(keyPress) ? .handled : .ignored
+        .onKeyPress(phases: [.down, .up]) { keyPress in
+            return switch keyPress.phase {
+            case .down:
+                console.keyDown(keyPress) ? .handled : .ignored
+            case .up:
+                console.keyUp(keyPress) ? .handled : .ignored
+            default:
+                .ignored
+            }
         }
     }
 }

--- a/happiNESsApp/ContentView.swift
+++ b/happiNESsApp/ContentView.swift
@@ -31,15 +31,8 @@ struct ContentView: View {
         .onAppear {
             focused = true
         }
-        .onKeyPress(phases: [.down, .up]) { keyPress in
-            return switch keyPress.phase {
-            case .down:
-                console.keyDown(keyPress) ? .handled : .ignored
-            case .up:
-                console.keyUp(keyPress) ? .handled : .ignored
-            default:
-                .ignored
-            }
+        .onKeyPress(phases: .all) { keyPress in
+            return console.handleKey(keyPress) ? .handled : .ignored
         }
     }
 }

--- a/happiNESsApp/happiNESsApp.swift
+++ b/happiNESsApp/happiNESsApp.swift
@@ -13,7 +13,7 @@ struct happiNESsApp: App {
     @State var console = try! Console()
 
     var body: some Scene {
-        WindowGroup {
+        Window("happiNESs", id: "main") {
             ContentView()
                 .environment(console)
         }


### PR DESCRIPTION
This PR introduces proper support for using the keyboard as a joypad in order to play NES games. The following is a summary of those changes:

* `JoypadButton` is now effectively an eight-bit register, supporting the eight buttons on an NES joypad.
* `Joypad` is a new struct which not only tracks the state of a `JoypadButton`, but is also tracks a `strobe` boolean which controls whether or not only the state of the `A` button is read from, or all that of all the buttons, as well as a `buttonIndex`. It also exposes a small APU to read from and write to its state, including a `readByteWithoutMutating()` method in case we ever need to hook it up to the tracer.
* `Bus` has been updated to instantiate a `Joypad` and forward read and write requests to it through address `0x4016`.
* `CPU`'s `buttonDown()` has been renamed to `handleButton()` which will handle key presses in all three SwiftUI states: `.up', `.down`, and `.repeat`.
* `Console`'s `keyDown()` has been replaced with `handleKey()` to translate key presses to their respective joypad buttons and call the proxy method in `CPU`.
* `ContentView`'s `onKeyPress()` handler now responds to all three SwiftUI states.
* `happiNESsApp` how instantiates a `Window` instead of a `WindowGroup`, which is the easiest way to make a SwiftUI app on macOS exit the program when the user closes the one window.