### PR TITLE
Support PPU scrolling

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		878D81452C7FEE3B0076ED30 /* image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 878D81432C7FEE3B0076ED30 /* image.xcassets */; };
 		878D81472C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878D81482C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
+		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		877E970A2C7E4716007513B5 /* Joypad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joypad.swift; sourceTree = "<group>"; };
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
+		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,6 +231,7 @@
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
 				8763D06D2C3A340C006C1B4F /* Tracing.swift */,
 				871F62332C6541D300132962 /* UInt16+bytes.swift */,
+				87D265142C9146F400C143B1 /* ViewPort.swift */,
 			);
 			path = happiNESs;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				871F62362C65631F00132962 /* ControllerRegister.swift in Sources */,
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
+				87D265152C9146F400C143B1 /* ViewPort.swift in Sources */,
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,

--- a/happiNESs/ControllerRegister.swift
+++ b/happiNESs/ControllerRegister.swift
@@ -59,6 +59,17 @@ public struct ControllerRegister: OptionSet {
         }
     }
 
+    public func nametableAddress() -> UInt16 {
+        switch self.rawValue & 0b0000_0011 {
+        case 0b0000_0000: 0x2000
+        case 0b0000_0001: 0x2400
+        case 0b0000_0010: 0x2800
+        case 0b0000_0011: 0x2C00
+        default:
+            fatalError("Impossible bit configuration for nametable address")
+        }
+    }
+
     mutating public func update(byte: UInt8) {
         self.rawValue = byte
     }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -319,12 +319,10 @@ extension PPU {
                 self.nmiInterrupt = nil
                 self.statusRegister[.verticalBlankStarted] = false
                 self.statusRegister[.spriteZeroHit] = false
-
-                return true
             }
         }
 
-        return false
+        return self.nmiInterrupt != nil
     }
 }
 

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -332,34 +332,6 @@ extension PPU {
         return self.chrRom![startIndex ..< startIndex + 16]
     }
 
-//    private func getBackgroundPalette(tileX: Int, tileY: Int) -> [NESColor] {
-//        let attributeTableIndex = ((tileY / 4) * 8) + (tileX / 4)
-//        let attributeByte = self.vram[Self.attributeTableOffset + attributeTableIndex]
-//
-//        let paletteIndex = switch ((tileX % 4) / 2, (tileY % 4) / 2) {
-//        case (0, 0):
-//            attributeByte & 0b0000_0011
-//        case (1, 0):
-//            (attributeByte >> 2) & 0b0000_0011
-//        case (0, 1):
-//            (attributeByte >> 4) & 0b0000_0011
-//        case (1, 1):
-//            (attributeByte >> 6) & 0b0000_0011
-//        default:
-//            fatalError("Whoops! We should never get here!")
-//        }
-//
-//        let paletteStartIndex = Int((paletteIndex * 4) + 1)
-//        return [
-//            0,
-//            paletteStartIndex,
-//            paletteStartIndex + 1,
-//            paletteStartIndex + 2,
-//        ].map { index in
-//            NESColor.systemPalette[Int(self.paletteTable[index])]
-//        }
-//    }
-
     private func getBackgroundPalette(attributeTable: ArraySlice<UInt8>,
                                       tileX: Int,
                                       tileY: Int) -> [NESColor] {
@@ -390,27 +362,9 @@ extension PPU {
         }
     }
 
-//    private func drawBackgroundTile(to screenBuffer: inout [NESColor],
-//                                    bankIndex: Int,
-//                                    tileIndex: Int,
-//                                    tileX: Int,
-//                                    tileY: Int) {
-//        let tileBytes = bytesForTileAt(bankIndex: bankIndex, tileIndex: tileIndex)
-//        let backgroundPalette = self.getBackgroundPalette(tileX: tileX, tileY: tileY)
-//
-//        for (y, var (firstByte, secondByte)) in zip(tileBytes.prefix(8), tileBytes.suffix(8)).enumerated() {
-//            for x in (0 ... 7).reversed() {
-//                let backgroundColorIndex = Int((secondByte & 0x01) << 1 | (firstByte & 0x01))
-//                firstByte >>= 1
-//                secondByte >>= 1
-//
-//                let backgroundColor = backgroundPalette[backgroundColorIndex]
-//                let pixelX = tileX * 8 + x
-//                let pixelY = tileY * 8 + y
-//                screenBuffer[Self.width * pixelY + pixelX] = backgroundColor
-//            }
-//        }
-//    }
+    private func setColorAt(x: Int, y: Int, in screenBuffer: inout [NESColor], to color: NESColor) {
+        screenBuffer[Self.width * y + x] = color
+    }
 
     private func drawBackgroundTile(to screenBuffer: inout [NESColor],
                                     attributeTable: ArraySlice<UInt8>,
@@ -438,9 +392,8 @@ extension PPU {
 
                 if pixelX >= viewPort.startX && pixelX < viewPort.endX &&
                     pixelY >= viewPort.startY && pixelY < viewPort.endY {
-                    screenBuffer[Self.width * (pixelY + shiftY) + (pixelX + shiftX)] = backgroundColor
+                    self.setColorAt(x: (pixelX + shiftX), y: (pixelY + shiftY), in: &screenBuffer, to: backgroundColor)
                 }
-//                screenBuffer[Self.width * pixelY + pixelX] = backgroundColor
             }
         }
     }
@@ -511,17 +464,6 @@ extension PPU {
         }
     }
 
-//    public func drawBackground(to screenBuffer: inout [NESColor]) {
-//        let bankIndex = self.controllerRegister[.backgroundPatternBankIndex] ? 1 : 0
-//        for i in 0 ..< Self.attributeTableOffset {
-//            let tileIndex = Int(self.vram[i])
-//            let tileX = (i % 32)
-//            let tileY = (i / 32)
-//
-//            self.drawBackgroundTile(to: &screenBuffer, bankIndex: bankIndex, tileIndex: tileIndex, tileX: tileX, tileY: tileY)
-//        }
-//    }
-
     private func getSpritePalette(paletteIndex: Int) -> [NESColor] {
         // NOTA BENE: The sprite palettes occupy the _upper_ 16 bytes
         // of the palette table, which is why the offset below is 0x11
@@ -575,9 +517,8 @@ extension PPU {
                         (tileX + 7 - x, tileY + 7 - y)
                     }
 
-                    let bufferIndex = Self.width * screenY + screenX
                     if screenX >= 0 && screenX < Self.width && screenY >= 0 && screenY < Self.height {
-                        screenBuffer[bufferIndex] = spriteColor
+                        self.setColorAt(x: screenX, y: screenY, in: &screenBuffer, to: spriteColor)
                     }
                 }
             }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -416,9 +416,12 @@ extension PPU {
 
     private func drawBackgroundTile(to screenBuffer: inout [NESColor],
                                     attributeTable: ArraySlice<UInt8>,
+                                    viewPort: ViewPort,
                                     tileIndex: Int,
                                     tileX: Int,
-                                    tileY: Int) {
+                                    tileY: Int,
+                                    shiftX: Int,
+                                    shiftY: Int) {
         let bankIndex = self.controllerRegister[.backgroundPatternBankIndex] ? 1 : 0
         let tileBytes = bytesForTileAt(bankIndex: bankIndex, tileIndex: tileIndex)
         let backgroundPalette = self.getBackgroundPalette(attributeTable: attributeTable,
@@ -434,7 +437,12 @@ extension PPU {
                 let backgroundColor = backgroundPalette[backgroundColorIndex]
                 let pixelX = tileX * 8 + x
                 let pixelY = tileY * 8 + y
-                screenBuffer[Self.width * pixelY + pixelX] = backgroundColor
+
+                if pixelX >= viewPort.startX && pixelX < viewPort.endX &&
+                    pixelY >= viewPort.startY && pixelY < viewPort.endY {
+                    screenBuffer[Self.width * (pixelY + shiftY) + (pixelX + shiftX)] = backgroundColor
+                }
+//                screenBuffer[Self.width * pixelY + pixelX] = backgroundColor
             }
         }
     }
@@ -453,9 +461,12 @@ extension PPU {
 
             self.drawBackgroundTile(to: &screenBuffer,
                                     attributeTable: attributeTable,
+                                    viewPort: viewPort,
                                     tileIndex: tileIndex,
                                     tileX: tileX,
-                                    tileY: tileY)
+                                    tileY: tileY,
+                                    shiftX: shiftX,
+                                    shiftY: shiftY)
         }
     }
 

--- a/happiNESs/ScrollRegister.swift
+++ b/happiNESs/ScrollRegister.swift
@@ -19,7 +19,7 @@ public struct ScrollRegister {
 
 extension ScrollRegister {
     mutating public func writeByte(byte: UInt8) {
-        if self.latch == false {
+        if self.latch {
             self.scrollY = byte
         } else {
             self.scrollX = byte

--- a/happiNESs/ViewPort.swift
+++ b/happiNESs/ViewPort.swift
@@ -1,0 +1,13 @@
+//
+//  ViewPort.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 9/10/24.
+//
+
+public struct ViewPort {
+    public let startX: Int
+    public let startY: Int
+    public let endX: Int
+    public let endY: Int
+}


### PR DESCRIPTION
This PR introduces changes so that my emulator supports games with scrolling. This changes include:

* The introduction of a small struct, `ViewPort` to represent the coordinates of a portion of the viewable screen.
* `ControllerRegister` now has a new method to compute and return the address of the beginning of the nametable represented by the state of its zeroth and first bits.
* A tiny bug fix in `ScrollRegister.writeByte()` that resulted in the wrong scroll value being set.
* A new method in `PPU`, namely `drawNametable()` which only draws the portion of the screen correspondent with the nametable and viewport passed in.
* The signatures of `drawBackground()`, `drawBackgroundTile()`, and `getBackgroundPalette()` all needed additional parameters in order to properly support scrolling.
* `PPU.tick()` needed to be updated to account for the sprite zero hit detection, although I strongly suspect that this is not quite right as the HUD for Super Mario Bros. doesn't stay fixed. This post talks about it in more detail: https://www.nesmakers.com/index.php?threads/sprite-zero-detection.6973/
* `PPU.tick()` also had a subtle bug that caused improper rendering for Super Mario Bros. due to not returning control to the GUI soon enough to render a new frame.
* `PPU.mirrorVramAddress()` has been renamed to `vramIndex()` and is noww heavily commented to better explain how mirroring correlates with VRAM addressing.