### PR TITLE
Rename `Rom` to `Cartridge` and make it a class instead of a struct

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		8719320C2C3366B000A73C22 /* Console.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719320A2C3366A900A73C22 /* Console.swift */; };
 		871932102C372F6900A73C22 /* Bus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719320F2C372F6900A73C22 /* Bus.swift */; };
 		871932122C37985700A73C22 /* Mirroring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871932112C37985700A73C22 /* Mirroring.swift */; };
-		871932142C3798B400A73C22 /* Rom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871932132C3798B400A73C22 /* Rom.swift */; };
+		871932142C3798B400A73C22 /* Cartridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871932132C3798B400A73C22 /* Cartridge.swift */; };
 		871F622D2C5C3C8A00132962 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 871F622C2C5C3C8900132962 /* nestest.nes */; };
 		871F622E2C5C3C8A00132962 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 871F622C2C5C3C8900132962 /* nestest.nes */; };
 		871F62302C62FE9E00132962 /* PPU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F622F2C62FE9E00132962 /* PPU.swift */; };
@@ -99,7 +99,7 @@
 		8719320A2C3366A900A73C22 /* Console.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Console.swift; path = happiNESsApp/Console.swift; sourceTree = SOURCE_ROOT; };
 		8719320F2C372F6900A73C22 /* Bus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bus.swift; sourceTree = "<group>"; };
 		871932112C37985700A73C22 /* Mirroring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mirroring.swift; sourceTree = "<group>"; };
-		871932132C3798B400A73C22 /* Rom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rom.swift; sourceTree = "<group>"; };
+		871932132C3798B400A73C22 /* Cartridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cartridge.swift; sourceTree = "<group>"; };
 		871F622C2C5C3C8900132962 /* nestest.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = nestest.nes; sourceTree = "<group>"; };
 		871F622F2C62FE9E00132962 /* PPU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPU.swift; sourceTree = "<group>"; };
 		871F62312C6314C900132962 /* AddressRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressRegister.swift; sourceTree = "<group>"; };
@@ -226,7 +226,7 @@
 				8744B18E2C1CBB46001B44B5 /* Opcode.swift */,
 				871F622F2C62FE9E00132962 /* PPU.swift */,
 				87184D042C7028F10003D090 /* PPUStatusRegister.swift */,
-				871932132C3798B400A73C22 /* Rom.swift */,
+				871932132C3798B400A73C22 /* Cartridge.swift */,
 				87184D0B2C7522B80003D090 /* ScrollRegister.swift */,
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
 				8763D06D2C3A340C006C1B4F /* Tracing.swift */,
@@ -421,7 +421,7 @@
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
 				87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */,
-				871932142C3798B400A73C22 /* Rom.swift in Sources */,
+				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
 				87184D0C2C7522B80003D090 /* ScrollRegister.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
 				878D81472C815E760076ED30 /* NESError.swift in Sources */,

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -12,6 +12,7 @@ public struct Bus {
     static let ppuRegistersMirrorsEnd: UInt16 = 0x3FFF;
 
     var ppu: PPU
+    var cartridge: Cartridge?
     var vram: [UInt8]
     var prgRom: [UInt8]?
     var cycles: Int
@@ -26,23 +27,15 @@ public struct Bus {
         self.joypad = Joypad()
     }
 
-    mutating public func loadRom(rom: Rom) {
-        self.ppu.chrRom = rom.chrRom
-        self.ppu.mirroring = rom.mirroring
-        self.prgRom = rom.prgRom
+    mutating public func loadCartridge(cartridge: Cartridge) {
+        self.cartridge = cartridge
+        self.ppu.cartridge = cartridge
     }
 }
 
 extension Bus {
     private func readPrgRom(address: UInt16) -> UInt8 {
-        var addressOffset = address - 0x8000
-
-        // Mirror if needed
-        if self.prgRom!.count == 0x4000 && addressOffset >= 0x4000 {
-            addressOffset = addressOffset % 0x4000
-        }
-
-        return self.prgRom![Int(addressOffset)]
+        return self.cartridge!.readPrgRom(address: address)
     }
 
     // NOTA BENE: Called directly by the tracer, as well as by readByte()

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -34,8 +34,8 @@ public struct CPU {
         self.tracingOn = tracingOn
     }
 
-    mutating public func loadRom(rom: Rom) {
-        self.bus.loadRom(rom: rom)
+    mutating public func loadCartridge(cartridge: Cartridge) {
+        self.bus.loadCartridge(cartridge: cartridge)
     }
 
     mutating public func reset() {

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -53,6 +53,10 @@ public class Cartridge {
         return self.chrRom[Int(address)]
     }
 
+    public func readTileFromChrRom(startAddress: UInt16) -> ArraySlice<UInt8> {
+        return self.chrRom[Int(startAddress) ..< Int(startAddress) + 16]
+    }
+
     public func readPrgRom(address: UInt16) -> UInt8 {
         var addressOffset = address - 0x8000
 

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 7/4/24.
 //
 
-public struct Rom {
+public class Cartridge {
     static let nesTag: [UInt8] = [0x4E, 0x45, 0x53, 0x1A]
     static let prgRomPageSize: Int = 16384
     static let chrRomPageSize: Int = 8192
@@ -47,5 +47,19 @@ public struct Rom {
         self.mapper = mapper
         self.prgRom = prgRom
         self.chrRom = chrRom
+    }
+
+    public func readChrRom(address: UInt16) -> UInt8 {
+        return self.chrRom[Int(address)]
+    }
+
+    public func readPrgRom(address: UInt16) -> UInt8 {
+        var addressOffset = address - 0x8000
+
+        // Mirror if needed
+        if self.prgRom.count == 0x4000 && addressOffset >= 0x4000 {
+            addressOffset = addressOffset % 0x4000
+        }
+        return self.prgRom[Int(addressOffset)]
     }
 }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -322,8 +322,8 @@ extension PPU {
 
 extension PPU {
     private func bytesForTileAt(bankIndex: Int, tileIndex: Int) -> ArraySlice<UInt8> {
-        let startIndex = (bankIndex * 0x1000) + tileIndex * 16
-        return self.cartridge!.chrRom[startIndex ..< startIndex + 16]
+        let startAddress = UInt16((bankIndex * 0x1000) + tileIndex * 16)
+        return self.cartridge!.readTileFromChrRom(startAddress: startAddress)
     }
 
     private func getBackgroundPalette(attributeTable: ArraySlice<UInt8>,

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -23,7 +23,7 @@ import SwiftUI
         KeyEquivalent("s") : .buttonB,
     ]
 
-    var romLoaded: Bool = false
+    var cartridgeLoaded: Bool = false
     var displayTimer: Timer!
 
     // NOTA BENE: We don't want the screen updated every single time something inside
@@ -42,12 +42,12 @@ import SwiftUI
     public func runGame(fileUrl: URL) throws {
         let data: Data = try Data(contentsOf: fileUrl)
         let romBytes = [UInt8](data)
-        guard let rom = Rom(bytes: romBytes) else {
+        guard let cartridge = Cartridge(bytes: romBytes) else {
             throw NESError.romCouldNotBeRead
         }
 
-        self.cpu.loadRom(rom: rom)
-        self.romLoaded = true
+        self.cpu.loadCartridge(cartridge: cartridge)
+        self.cartridgeLoaded = true
         self.cpu.reset()
 
         // We need to do this to avoid keeping around previously registered timers

--- a/happiNESsApp/ContentView.swift
+++ b/happiNESsApp/ContentView.swift
@@ -24,7 +24,7 @@ struct ContentView: View {
     @FocusState private var focused: Bool
 
     var body: some View {
-        if self.console.romLoaded {
+        if self.console.cartridgeLoaded {
             Screen(screenBuffer: console.screenBuffer)
             .padding()
             .focusable()

--- a/happiNESsTests/Helpers.swift
+++ b/happiNESsTests/Helpers.swift
@@ -7,7 +7,7 @@
 
 @testable import happiNESs
 
-func makeRom(programBytes: [UInt8]) -> Rom {
+func makeRom(programBytes: [UInt8]) -> Cartridge {
     let header: [UInt8] = [
         0x4E, 0x45, 0x53, 0x1A,
         0x02, 0x01, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -16,7 +16,7 @@ func makeRom(programBytes: [UInt8]) -> Rom {
     let chrRomBytes = [UInt8](repeating: 0x00, count: 8192)
     let romBytes = header + prgRomBytes + chrRomBytes
 
-    return Rom(bytes: romBytes)!
+    return Cartridge(bytes: romBytes)!
 }
 
 func makeCpu(programBytes: [UInt8]) -> CPU {

--- a/happiNESsTests/RomTests.swift
+++ b/happiNESsTests/RomTests.swift
@@ -19,7 +19,7 @@ final class RomTests: XCTestCase {
         let chrRomBytes = [UInt8](repeating: 0x00, count: 8192)
         let romBytes = header + prgRomBytes + chrRomBytes
 
-        if let badRom = Rom(bytes: romBytes) {
+        if let badRom = Cartridge(bytes: romBytes) {
             XCTFail("ROM with bad tag should not have loaded!")
         }
     }
@@ -34,7 +34,7 @@ final class RomTests: XCTestCase {
         let chrRomBytes = [UInt8](repeating: 0x00, count: 8192)
         let romBytes = header + prgRomBytes + chrRomBytes
 
-        if let badRom = Rom(bytes: romBytes) {
+        if let badRom = Cartridge(bytes: romBytes) {
             XCTFail("ROM with bad iNES version should not have loaded!")
         }
     }
@@ -49,7 +49,7 @@ final class RomTests: XCTestCase {
         let chrBytes = [UInt8](repeating: 0x00, count: 8192)
 
         let allBytes = header + trainer + prgBytes + chrBytes
-        if let rom = Rom(bytes: allBytes) {
+        if let rom = Cartridge(bytes: allBytes) {
             XCTAssertEqual(rom.prgRom[0], 0xA9)
             XCTAssertEqual(rom.prgRom[1], 0x42)
         } else {


### PR DESCRIPTION
In order to be able to load cartridges with larger sizes of CHR and PRG ROM, including some of the test ROMs such as blargg's `official_only.nes`, we need to be able to support mappers. Up until now, the `Bus` had a copy of the PRG ROM and `PPU` had a copy of the CHR ROM, as well as a memory mapping strategy baked into its logic for reading. This is no good as different cartridges have different memory capacities. 

The _cartridge_ ought to own the logic of how CHR and PRG ROM is addressed, and there ultimately needs to be some sort of abstraction for handling _multiple_ memory configurations. This PR is a first step towards being able to do this by first making `Cartridge` a class, that in some cases needs to manage mutable state, and giving `Bus` and `PPU` a reference to it. This sets us up in the future for creating `Cartridge`s with an arbitrary memory mapper without `Bus` and `PPU` having to know which one it is; all of the address management is done in `Cartridge`.