### PR TITLE
Fix hang just before Super Mario Bros. level 1-2

### DIFF
--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -570,6 +570,24 @@ extension CPU {
     }
 
     mutating func sha(addressingMode: AddressingMode) -> (Bool, Int) {
+        let (address2, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
+
+        let address: UInt16
+        switch addressingMode {
+        case .indirectY:
+            let pos = self.readByte(address: self.programCounter)
+            address = self.readWord(address: UInt16(pos)) + UInt16(self.yRegister)
+        case .absoluteY:
+            address = self.readWord(address: self.programCounter) + UInt16(self.yRegister)
+        default:
+            fatalError("Unsupported addressing mode for SHA instruction")
+        }
+
+        print("Address: \(address)")
+        print("Address2: \(address2)")
+        let result = self.accumulator & self.xRegister & address.highByte
+        self.writeByte(address: address, byte: result)
+
         return (false, 0)
     }
 

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -412,7 +412,7 @@ extension CPU {
         // NOTA BENE: We need to set the so-called B flag upon a push to the stack:
         //
         //    https://www.nesdev.org/wiki/Status_flags#The_B_flag
-        self.pushStack(byte: self.statusRegister.rawValue | 0b0001_0000)
+        self.pushStack(byte: self.statusRegister.rawValue | 0b0011_0000)
 
         return (false, 0)
     }
@@ -570,21 +570,7 @@ extension CPU {
     }
 
     mutating func sha(addressingMode: AddressingMode) -> (Bool, Int) {
-        let (address2, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
-
-        let address: UInt16
-        switch addressingMode {
-        case .indirectY:
-            let pos = self.readByte(address: self.programCounter)
-            address = self.readWord(address: UInt16(pos)) + UInt16(self.yRegister)
-        case .absoluteY:
-            address = self.readWord(address: self.programCounter) + UInt16(self.yRegister)
-        default:
-            fatalError("Unsupported addressing mode for SHA instruction")
-        }
-
-        print("Address: \(address)")
-        print("Address2: \(address2)")
+        let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let result = self.accumulator & self.xRegister & address.highByte
         self.writeByte(address: address, byte: result)
 
@@ -932,12 +918,9 @@ extension CPU {
             let newAddress = baseAddress &+ UInt16(self.yRegister)
             return (newAddress, wasPageCrossed(fromAddress: baseAddress, toAddress: newAddress))
         case .relative:
-            let offset = UInt16(self.readByte(address: address)) &+ 1
-            let newAddress = if offset >> 7 == 0 {
-                self.programCounter &+ offset
-            } else {
-                self.programCounter &+ offset &- 0x0100
-            }
+            let signedOffset = Int(Int8(bitPattern: self.readByte(address: address)))
+            let signedNewAddress = Int(self.programCounter) + signedOffset + 1
+            let newAddress = UInt16(truncatingIfNeeded: signedNewAddress)
 
             return (newAddress, wasPageCrossed(fromAddress: address + 1, toAddress: newAddress))
         default:

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -569,6 +569,10 @@ extension CPU {
         return (false, 0)
     }
 
+    mutating func sha(addressingMode: AddressingMode) -> (Bool, Int) {
+        return (false, 0)
+    }
+
     mutating func slo(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let oldValue = self.readByte(address: address)
@@ -812,6 +816,8 @@ extension CPU {
                 self.sed()
             case .sei:
                 self.sei()
+            case .shaAbsoluteY, .shaIndirectY:
+                self.sha(addressingMode: opcode.addressingMode)
             case .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY:
                 self.slo(addressingMode: opcode.addressingMode)
             case .sreAbsolute, .sreAbsoluteX, .sreAbsoluteY, .sreZeroPage, .sreZeroPageX, .sreIndirectX, .sreIndirectY:

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -242,6 +242,9 @@ enum Opcode: UInt8 {
     case sed = 0xF8
     case sei = 0x78
 
+    case shaAbsoluteY = 0x9F
+    case shaIndirectY = 0x93
+
     case sloAbsolute = 0x0F
     case sloAbsoluteX = 0x1F
     case sloAbsoluteY = 0x1B
@@ -520,6 +523,9 @@ extension Opcode {
         case .sec: .implicit
         case .sed: .implicit
         case .sei: .implicit
+
+        case .shaAbsoluteY: .absoluteY
+        case .shaIndirectY: .indirectY
 
         case .sloAbsolute: .absolute
         case .sloAbsoluteX: .absoluteX
@@ -802,6 +808,9 @@ extension Opcode {
         case .sed: 1
         case .sei: 1
 
+        case .shaAbsoluteY: 3
+        case .shaIndirectY: 2
+
         case .sloAbsolute: 3
         case .sloAbsoluteX: 3
         case .sloAbsoluteY: 3
@@ -868,6 +877,7 @@ extension Opcode {
                 .rraAbsolute, .rraAbsoluteX, .rraAbsoluteY, .rraZeroPage, .rraZeroPageX, .rraIndirectX, .rraIndirectY,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
                 .sbcImmediate2,
+                .shaAbsoluteY, .shaIndirectY,
                 .sloAbsolute, .sloAbsoluteX, .sloAbsoluteY, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectY,
                 .sreAbsolute, .sreAbsoluteX, .sreAbsoluteY, .sreZeroPage, .sreZeroPageX, .sreIndirectX, .sreIndirectY:
             return false
@@ -1115,6 +1125,9 @@ extension Opcode {
         case .sec: 2
         case .sed: 2
         case .sei: 2
+
+        case .shaAbsoluteY: 5
+        case .shaIndirectY: 6
 
         case .sloAbsolute: 6
         case .sloAbsoluteX: 7

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -306,6 +306,8 @@ extension PPU {
                 if self.controllerRegister[.generateNmi] {
                     self.nmiInterrupt = 1
                 }
+
+                return true
             }
 
             if self.scanline >= Self.scanlinesPerFrame {
@@ -316,7 +318,7 @@ extension PPU {
             }
         }
 
-        return self.nmiInterrupt != nil
+        return false
     }
 }
 


### PR DESCRIPTION
So… the latest bug I’ve been trying to fix in my emulator happens when I complete level 1-1 on Super Mario Bros. Normally, when you jump onto the flagpole, the game takes over, shows fireworks and then another screen showing Mario walking into a pipe into the next level. 

But that never happened and instead, the game crashed, due to an opcode, namely `0x93`, not having been implemented. That turned out to be yet another undocumented instruction (the SHA instruction), and so I thought, "Oh! This ought to be a simple fix."

I implemented the SHA instruction and reran the game… aaaaaannnndddd, NOAP, lol… that led to the game hanging with no errors...

And so, the next thing I did was 1) to wait until I got to the very end of level 1-1 _before_ jumping onto the flagpole, 2) activate a breakpoint in Xcode, 3) turn on tracing via the LLDB debugger, and then 4) watch for anything weird…

And indeed, the first thing I saw was that the emulator was endlessly  looping over the same four or five instructions. Something clearly went awry upstream…

The next thing, per a suggestion from the lovely Becca, was to run the game on the Rust version (since it didn’t suffer from the same bug), turn on tracing, then compare results. That required me to implement several functions that only _read_ CPU state and didn’t both read and mutate it…

Once I did that, I followed the same steps listed above but for the Rust version, and I noticed was that the stack pointer was _never_ set to zero like it was at some point in _my_ emulator. Hmmmmmm…

So… Becca and I kept scrolling back through the trace for my emulator to the point where the stack pointer was erroneously set to zero by a TXS instruction. We noted the memory location of that instruction, and then looked at the previously executed instruction which was a branching one…

Becca had meanwhile found actual disassembled source code for the Super Mario Bros. game, and we saw that the address of that TXS instruction was actually located in a part of the program intended to be _data_ not code… 

And so it was clear that the previous branch instruction was not working properly, and incorrectly jumping to a part of the program where my emulator interpreted that byte as an _instruction_ instead of a datum…

And it turned out that there was a bug in my handling of branch instructions; my code wasn’t properly computing the next address to jump to when handling instructions in the `.relative` addressing mode. Specifically, I wasn’t doing two’s complement arithmetic properly, so under certain conditions the emulator would jump to the wrong address…

(Curiously this only happened when I got to the end of the first level!)

Once Becca helped me implement the relative addressing correctly, the game worked!!! I was able to go onto level 1-2! Wheeeeeeee!!!

Other things included in this branch:

* Although the SHA instruction is implemented in this branch, it actually has nothing to do with the bug fix! But it is left in for when it _will_ be needed.
* There was also a small patch to the PHP instruction (thinking that might have had something to do with the bug) which wasn't setting all of the necessary bits before pushing onto the stack, but that also had no effect. 
* I had inadvertently undone one of the fixes that Becca had put in to address proper screen updating; that is back in this branch as well.





