### PR TITLE
Be able to load one ROM after another

### DIFF
--- a/happiNESs/AddressRegister.swift
+++ b/happiNESs/AddressRegister.swift
@@ -16,6 +16,11 @@ extension AddressRegister {
         self.highPointer = true
     }
 
+    mutating public func reset() {
+        self.address = 0x0000
+        self.highPointer = true
+    }
+
     mutating public func setAddress(address: UInt16) {
         self.address = address
     }

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -31,6 +31,10 @@ public struct Bus {
         self.cartridge = cartridge
         self.ppu.cartridge = cartridge
     }
+
+    mutating public func reset() {
+        self.ppu.reset()
+    }
 }
 
 extension Bus {

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -46,6 +46,7 @@ public struct CPU {
         self.stackPointer = Self.resetStackPointerValue
         self.programCounter = self.readWord(address: Self.resetVectorAddress)
 
+        self.bus.reset()
         // TODO: Look more deeply into whether or not this is the best strategy
         // for simulating the initial number of CPU cycles when resetting the CPU
         let _ = self.bus.tick(cycles: 7)

--- a/happiNESs/ControllerRegister.swift
+++ b/happiNESs/ControllerRegister.swift
@@ -12,6 +12,10 @@ public struct ControllerRegister: OptionSet {
         self.rawValue = rawValue
     }
 
+    mutating public func reset() {
+        self.rawValue = 0
+    }
+
     //  7 6 5 4 3 2 1 0
     //  V P H B S I N N
     //  | | | | | | | +--- Nametable bit 1

--- a/happiNESs/MaskRegister.swift
+++ b/happiNESs/MaskRegister.swift
@@ -50,7 +50,7 @@ public struct MaskRegister: OptionSet {
         }
     }
 
-    mutating func reset() {
+    mutating public func reset() {
         self.rawValue = 0b0000_0000
     }
 

--- a/happiNESs/OAMRegister.swift
+++ b/happiNESs/OAMRegister.swift
@@ -13,6 +13,11 @@ public struct OAMRegister {
         self.address = 0
         self.data = [UInt8](repeating: 0x00, count: 256)
     }
+
+    mutating public func reset() {
+        self.address = 0
+        self.data = [UInt8](repeating: 0x00, count: 256)
+    }
 }
 
 extension OAMRegister {

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -86,6 +86,23 @@ public struct PPU {
         self.scanline = 0
         self.nmiInterrupt = nil
     }
+
+    mutating public func reset() {
+        self.internalDataBuffer = 0x00
+        self.vram = [UInt8](repeating: 0x00, count: 2048)
+        self.paletteTable = [UInt8](repeating: 0x00, count: 32)
+
+        self.addressRegister.reset()
+        self.controllerRegister.reset()
+        self.maskRegister.reset()
+        self.oamRegister.reset()
+        self.scrollRegister.reset()
+        self.statusRegister.reset()
+
+        self.cycles = 0
+        self.scanline = 0
+        self.nmiInterrupt = nil
+    }
 }
 
 extension PPU {

--- a/happiNESs/ScrollRegister.swift
+++ b/happiNESs/ScrollRegister.swift
@@ -15,6 +15,12 @@ public struct ScrollRegister {
         self.scrollY = 0
         self.latch = false
     }
+
+    mutating public func reset() {
+        self.scrollX = 0
+        self.scrollY = 0
+        self.latch = false
+    }
 }
 
 extension ScrollRegister {


### PR DESCRIPTION
This turned out to be a fairly simple set of changes. Previously, after successfully loading one ROM, regardless of playing the game or not, upon trying to load a second one led to the emulator freezing. The reason was that the emulator was in a mixed state, and so the solution was to make sure that every single component in the system is reset after loading a cartridge, not just the CPU.