### PR TITLE
Introduce `Mapper` enum and support a couple of additional cartridge types

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		878D81472C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878D81482C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
+		87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* Mapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
+		87D265162C9DECAF00C143B1 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -218,6 +220,7 @@
 				8744B1902C1CC0C4001B44B5 /* CPU.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
+				87D265162C9DECAF00C143B1 /* Mapper.swift */,
 				87184D092C7511F90003D090 /* MaskRegister.swift */,
 				871932112C37985700A73C22 /* Mirroring.swift */,
 				871932062C30E91D00A73C22 /* NESColor.swift */,
@@ -422,6 +425,7 @@
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
 				87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */,
 				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
+				87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */,
 				87184D0C2C7522B80003D090 /* ScrollRegister.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
 				878D81472C815E760076ED30 /* NESError.swift in Sources */,

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -120,7 +120,7 @@ extension Bus {
         case 0x4016:
             self.joypad.writeByte(byte: byte)
         case 0x8000 ... 0xFFFF:
-            self.cartridge!.setChrBankIndex(byte: byte)
+            self.cartridge!.writeByte(address: address, byte: byte)
         default:
             // TODO: Implement memory writing to these addresses?
             break

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -14,7 +14,6 @@ public struct Bus {
     public var ppu: PPU
     var cartridge: Cartridge?
     var vram: [UInt8]
-    var prgRom: [UInt8]?
     var cycles: Int
     var joypad: Joypad
 

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -38,8 +38,8 @@ public struct Bus {
 }
 
 extension Bus {
-    private func readPrgRom(address: UInt16) -> UInt8 {
-        return self.cartridge!.readPrgRom(address: address)
+    private func readPrg(address: UInt16) -> UInt8 {
+        return self.cartridge!.readPrg(address: address)
     }
 
     // NOTA BENE: Called directly by the tracer, as well as by readByte()
@@ -62,7 +62,7 @@ extension Bus {
         case 0x4016:
             return self.joypad.readByteWithoutMutating()
         case 0x8000 ... 0xFFFF:
-            return self.readPrgRom(address: address)
+            return self.readPrg(address: address)
         default:
             // TODO: Implement memory reading from these addresses?
             return 0x00
@@ -120,7 +120,7 @@ extension Bus {
         case 0x4016:
             self.joypad.writeByte(byte: byte)
         case 0x8000 ... 0xFFFF:
-            fatalError("Attempt to write to cartridge ROM space")
+            self.cartridge!.setChrBankIndex(byte: byte)
         default:
             // TODO: Implement memory writing to these addresses?
             break

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -16,15 +16,14 @@ public class Cartridge {
     public var chrRom: [UInt8]
     public var chrBankIndex: Int
 
-    // TODO: Throw errors instead of returning nil
-    public init?(bytes: [UInt8]) {
+    public init(bytes: [UInt8]) throws {
         if Array(bytes[0..<4]) != Self.nesTag {
-            return nil
+            throw NESError.romNotInInesFormat
         }
 
         let inesVersion = (bytes[7] >> 2) & 0b11;
         if inesVersion != 0 {
-            return nil
+            throw NESError.versionTwoPointOhNotSupported
         }
 
         let fourScreenBit = bytes[6] & 0b1000 != 0;
@@ -37,7 +36,7 @@ public class Cartridge {
 
         let mapperNumber = (bytes[7] & 0b1111_0000) | (bytes[6] >> 4)
         guard let mapper = Mapper(rawValue: mapperNumber) else {
-            return nil
+            throw NESError.mapperNotSupported(Int(mapperNumber))
         }
         self.mapper = mapper
 

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -63,7 +63,9 @@ public enum Mapper: UInt8 {
     public func setChrBankIndex(byte: UInt8, cartridge: Cartridge) {
         switch self {
         case .nrom:
-            fatalError("Cannot write to CHR ROM for mapper type NROM")
+            // For some reason Ms. Pacman calls this even though there is
+            // no bank switching for NROM games, so for now just ignore it.
+            break
         case .cnrom:
             let bankIndex = byte & 0b0000_0011
             cartridge.chrBankIndex = Int(bankIndex)

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -1,0 +1,72 @@
+//
+//  Mapper.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 9/20/24.
+//
+
+public enum Mapper: UInt8 {
+    case nrom = 0
+    case cnrom = 3
+
+    private func logIgnoredWrite(address: UInt16, byte: UInt8, inChr: Bool) {
+        print(String(format: "Ignored write of %0x to %0x in \(inChr ? "CHR" : "PRG")", byte, address))
+    }
+
+    private func chrMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
+        switch self {
+        case .nrom:
+            return Int(address)
+        case .cnrom:
+            return cartridge.chrBankIndex * 0x2000 + Int(address)
+        }
+    }
+
+    public func readPrg(address: UInt16, cartridge: Cartridge) -> UInt8 {
+        switch self {
+        case .nrom, .cnrom:
+            var addressOffset = address - 0x8000
+
+            // Mirror if needed
+            if cartridge.prgRom.count == 0x4000 {
+                addressOffset = addressOffset % 0x4000
+            }
+
+            return cartridge.prgRom[Int(addressOffset)]
+        }
+    }
+
+    public func readChr(address: UInt16, cartridge: Cartridge) -> UInt8 {
+        let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
+        return cartridge.chrRom[memoryIndex]
+    }
+
+    public func readTileFromChr(startAddress: UInt16, cartridge: Cartridge) -> ArraySlice<UInt8> {
+        let startMemoryIndex = self.chrMemoryIndex(for: startAddress, cartridge: cartridge)
+        return cartridge.chrRom[startMemoryIndex ..< startMemoryIndex + 16]
+    }
+
+    public func writePrg(address: UInt16, byte: UInt8, cartridge: Cartridge) {
+        switch self {
+        case .nrom, .cnrom:
+            logIgnoredWrite(address: address, byte: byte, inChr: false)
+        }
+    }
+
+    public func writeChr(address: UInt16, byte: UInt8, cartridge: Cartridge) {
+        switch self {
+        case .nrom, .cnrom:
+            logIgnoredWrite(address: address, byte: byte, inChr: true)
+        }
+    }
+
+    public func setChrBankIndex(byte: UInt8, cartridge: Cartridge) {
+        switch self {
+        case .nrom:
+            fatalError("Cannot write to CHR ROM for mapper type NROM")
+        case .cnrom:
+            let bankIndex = byte & 0b0000_0011
+            cartridge.chrBankIndex = Int(bankIndex)
+        }
+    }
+}

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -7,18 +7,37 @@
 
 public enum Mapper: UInt8 {
     case nrom = 0
+    case uxrom = 2
     case cnrom = 3
 
     private func logIgnoredWrite(address: UInt16, byte: UInt8, inChr: Bool) {
         print(String(format: "Ignored write of %0x to %0x in \(inChr ? "CHR" : "PRG")", byte, address))
     }
 
-    private func chrMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
+    private func prgMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
         switch self {
-        case .nrom:
+        case .nrom, .cnrom:
             return Int(address)
-        case .cnrom:
-            return cartridge.chrBankIndex * 0x2000 + Int(address)
+        case .uxrom:
+            switch address {
+            case 0x8000 ... 0xBFFF:
+                return cartridge.prgBankIndex * 0x4000 + Int(address - 0x8000)
+            case 0xC000 ... 0xFFFF:
+                let lastBankStart = 7 * 0x4000
+                return lastBankStart + Int(address - 0xC000)
+            default:
+                fatalError("Whoops! tried addressing PRG memory out of range")
+            }
+        }
+    }
+
+    public func setPrgBankIndex(byte: UInt8, cartridge: Cartridge) {
+        switch self {
+        case .nrom, .cnrom:
+            break
+        case .uxrom:
+            let bankIndex = byte & 0b0000_1111
+            cartridge.prgBankIndex = Int(bankIndex)
         }
     }
 
@@ -28,47 +47,62 @@ public enum Mapper: UInt8 {
             var addressOffset = address - 0x8000
 
             // Mirror if needed
-            if cartridge.prgRom.count == 0x4000 {
+            if cartridge.prgMemory.count == 0x4000 {
                 addressOffset = addressOffset % 0x4000
             }
 
-            return cartridge.prgRom[Int(addressOffset)]
+            return cartridge.prgMemory[Int(addressOffset)]
+        case .uxrom:
+            let memoryIndex = self.prgMemoryIndex(for: address, cartridge: cartridge)
+            return cartridge.prgMemory[memoryIndex]
         }
-    }
-
-    public func readChr(address: UInt16, cartridge: Cartridge) -> UInt8 {
-        let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
-        return cartridge.chrRom[memoryIndex]
-    }
-
-    public func readTileFromChr(startAddress: UInt16, cartridge: Cartridge) -> ArraySlice<UInt8> {
-        let startMemoryIndex = self.chrMemoryIndex(for: startAddress, cartridge: cartridge)
-        return cartridge.chrRom[startMemoryIndex ..< startMemoryIndex + 16]
     }
 
     public func writePrg(address: UInt16, byte: UInt8, cartridge: Cartridge) {
         switch self {
-        case .nrom, .cnrom:
+        case .nrom, .uxrom, .cnrom:
             logIgnoredWrite(address: address, byte: byte, inChr: false)
         }
     }
 
-    public func writeChr(address: UInt16, byte: UInt8, cartridge: Cartridge) {
+    private func chrMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
         switch self {
-        case .nrom, .cnrom:
-            logIgnoredWrite(address: address, byte: byte, inChr: true)
+        case .nrom, .uxrom:
+            return Int(address)
+        case .cnrom:
+            return cartridge.chrBankIndex * 0x2000 + Int(address)
         }
     }
 
     public func setChrBankIndex(byte: UInt8, cartridge: Cartridge) {
         switch self {
-        case .nrom:
+        case .nrom, .uxrom:
             // For some reason Ms. Pacman calls this even though there is
             // no bank switching for NROM games, so for now just ignore it.
             break
         case .cnrom:
             let bankIndex = byte & 0b0000_0011
             cartridge.chrBankIndex = Int(bankIndex)
+        }
+    }
+
+    public func readChr(address: UInt16, cartridge: Cartridge) -> UInt8 {
+        let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
+        return cartridge.chrMemory[memoryIndex]
+    }
+
+    public func readTileFromChr(startAddress: UInt16, cartridge: Cartridge) -> ArraySlice<UInt8> {
+        let startMemoryIndex = self.chrMemoryIndex(for: startAddress, cartridge: cartridge)
+        return cartridge.chrMemory[startMemoryIndex ..< startMemoryIndex + 16]
+    }
+
+    public func writeChr(address: UInt16, byte: UInt8, cartridge: Cartridge) {
+        switch self {
+        case .nrom, .cnrom:
+            logIgnoredWrite(address: address, byte: byte, inChr: true)
+        case .uxrom:
+            let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
+            cartridge.chrMemory[memoryIndex] = byte
         }
     }
 }

--- a/happiNESs/NESError.swift
+++ b/happiNESs/NESError.swift
@@ -10,7 +10,9 @@ import Foundation
 enum NESError: Error, LocalizedError {
     case romFileCouldNotBeSelected
     case romFileCouldNotBeOpened
-    case romCouldNotBeRead
+    case romNotInInesFormat
+    case versionTwoPointOhNotSupported
+    case mapperNotSupported(Int)
 
     var errorDescription: String? {
         switch self {
@@ -18,8 +20,12 @@ enum NESError: Error, LocalizedError {
             "Unable to select file"
         case .romFileCouldNotBeOpened:
             "Unable to open file"
-        case .romCouldNotBeRead:
-            "Unable to run file"
+        case .romNotInInesFormat:
+            "ROM file not in iNES format"
+        case .versionTwoPointOhNotSupported:
+            "NES 2.0 ROMs not yet supported"
+        case .mapperNotSupported(let mapperNumber):
+            String(format: "Mapper number %03d not supported", mapperNumber)
         }
     }
 }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -229,7 +229,7 @@ extension PPU {
         switch address {
         case 0x0000 ... 0x1FFF:
             // TODO: Again... I'm concerned about the magnitude of `address` here and how large `chrRom` is
-            return (self.internalDataBuffer, self.cartridge!.readChrRom(address: address))
+            return (self.internalDataBuffer, self.cartridge!.readChr(address: address))
         case 0x2000 ... 0x2FFF:
             // TODO: Same same concern as above
             return (internalDataBuffer, self.vram[self.vramIndex(from: address)])
@@ -342,7 +342,7 @@ extension PPU {
 extension PPU {
     private func bytesForTileAt(bankIndex: Int, tileIndex: Int) -> ArraySlice<UInt8> {
         let startAddress = UInt16((bankIndex * 0x1000) + tileIndex * 16)
-        return self.cartridge!.readTileFromChrRom(startAddress: startAddress)
+        return self.cartridge!.readTileFromChr(startAddress: startAddress)
     }
 
     private func getBackgroundPalette(attributeTable: ArraySlice<UInt8>,

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -266,8 +266,7 @@ extension PPU {
 
         switch address {
         case 0x0000 ... 0x1FFF:
-            let message = String(format: "Attempt to write to chr rom space: %04X", address)
-            print(message)
+            self.cartridge!.writeChr(address: address, byte: byte)
         case 0x2000 ... 0x2FFF:
             self.vram[self.vramIndex(from: address)] = byte
         case 0x3000 ... 0x3EFF:

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -42,9 +42,7 @@ import SwiftUI
     public func runGame(fileUrl: URL) throws {
         let data: Data = try Data(contentsOf: fileUrl)
         let romBytes = [UInt8](data)
-        guard let cartridge = Cartridge(bytes: romBytes) else {
-            throw NESError.romCouldNotBeRead
-        }
+        let cartridge = try Cartridge(bytes: romBytes)
 
         self.cpu.loadCartridge(cartridge: cartridge)
         self.cartridgeLoaded = true

--- a/happiNESsTests/RomTests.swift
+++ b/happiNESsTests/RomTests.swift
@@ -50,8 +50,8 @@ final class RomTests: XCTestCase {
 
         let allBytes = header + trainer + prgBytes + chrBytes
         if let rom = Cartridge(bytes: allBytes) {
-            XCTAssertEqual(rom.prgRom[0], 0xA9)
-            XCTAssertEqual(rom.prgRom[1], 0x42)
+            XCTAssertEqual(rom.prgMemory[0], 0xA9)
+            XCTAssertEqual(rom.prgMemory[1], 0x42)
         } else {
             XCTFail("ROM should have been successfully constructed")
         }


### PR DESCRIPTION
This PR is an initial attempt to support cartridge types other than those with NROM boards (mapper number 000). Up until this now, only games like 1942 and Pacman were playable, with any other cartridge type resulting in a crash of some sort. Now cartridges with UxROM (mapper number 002) and CNROM (mapper number 003) boards are minimally playable with the introduction of a new `Mapper` enum. This new struct allows for memory access requests from the PPU to the cartridge to be routed to the correct PRG or CHR address.

Other changes include:

* In addition to the new memory mapping strategy, CHR memory can now be written too, as the CNROM requires.
* There is now improved error handling in the GUI, which instead of simply displaying a generic message, "ROM could not be loaded", will now display something much more specific such as when the ROM file lacks the iNES tag, is a NES 2.0 ROM, or employs an unsupported mapper.

There is still much more work to do as the way that the cartridge is addressed by both the bus and the PPU is not quite properly abstracted.

Also, games like Gradius and Castlevania do not quite render properly even thought they do load and can be minimally played, but that's likely a problem with the renderer _not_ anything to do with the mapper.
