### PR TITLE
Implement pixel-level rendering

### DIFF
--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -1032,12 +1032,6 @@ extension CPU {
 }
 
 extension CPU {
-    mutating public func updateScreenBuffer(_ screenBuffer: inout [NESColor]) {
-        self.bus.ppu.updateScreenBuffer(&screenBuffer)
-    }
-}
-
-extension CPU {
     mutating private func interruptNmi() {
         self.pushStack(word: self.programCounter)
 

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -293,20 +293,18 @@ extension PPU {
 }
 
 extension PPU {
-    mutating func pollNMIInterrupt() -> UInt8? {
-        let result = self.nmiInterrupt
-        self.nmiInterrupt = nil
-        return result
+    static public func makeEmptyScreenBuffer() -> [NESColor] {
+        [NESColor](repeating: .black, count: Self.width * Self.height)
     }
 
-    mutating func isSpriteZeroHit(cycles: Int) -> Bool {
-        let y = self.oamRegister.data[0]
-        let x = self.oamRegister.data[3]
-        return (y == self.scanline) && x <= cycles && self.maskRegister[.showSprites]
-    }
-
-    mutating public func getScreenBuffer(_ otherBuffer: inout [NESColor]) {
+    // We effectively are doing double buffering here to maximize performance.
+    mutating public func updateScreenBuffer(_ otherBuffer: inout [NESColor]) {
         swap(&self.screenBuffer, &otherBuffer)
+    }
+
+    private func bytesForTileAt(bankIndex: Int, tileIndex: Int) -> ArraySlice<UInt8> {
+        let startAddress = UInt16((bankIndex * 0x1000) + tileIndex * 16)
+        return self.cartridge!.readTileFromChr(startAddress: startAddress)
     }
 
     mutating private func setColorAt(x: Int, y: Int, to color: NESColor) {
@@ -390,6 +388,21 @@ extension PPU {
                                               tileY: nametableRow)
     }
 
+    private func getSpritePalette(paletteIndex: Int) -> [NESColor] {
+        // NOTA BENE: The sprite palettes occupy the _upper_ 16 bytes
+        // of the palette table, which is why the offset below is 0x11
+        // and not 0x01.
+        let paletteStartIndex = Int(0x11 + (paletteIndex * 4))
+        return [
+            0,
+            paletteStartIndex,
+            paletteStartIndex + 1,
+            paletteStartIndex + 2,
+        ].map { index in
+            NESColor.systemPalette[Int(self.paletteTable[index])]
+        }
+    }
+
     private func getSpriteColor(backgroundPriority: Bool, x: Int, y: Int) -> NESColor? {
         if let spriteIndex = self.spriteIndicesForCurrentScanline.first(
             where: { oamIndex in
@@ -466,6 +479,9 @@ extension PPU {
         setColorAt(x: x, y: y, to: color)
     }
 
+    // This is partly a performance optimization and partly an emulation
+    // of what happens in the NES, whereby we cache the first eight sprites
+    // that lie on the current scanline.
     mutating private func cacheSpriteIndices() {
         let allSpriteIndices = stride(from: 0, to: self.oamRegister.data.count, by: 4)
         self.spriteIndicesForCurrentScanline = allSpriteIndices.filter({
@@ -478,6 +494,20 @@ extension PPU {
 
                 return false
         }).prefix(8)
+    }
+}
+
+extension PPU {
+    mutating func pollNMIInterrupt() -> UInt8? {
+        let result = self.nmiInterrupt
+        self.nmiInterrupt = nil
+        return result
+    }
+
+    mutating func isSpriteZeroHit(cycles: Int) -> Bool {
+        let y = self.oamRegister.data[0]
+        let x = self.oamRegister.data[3]
+        return (y == self.scanline) && x <= cycles && self.maskRegister[.showSprites]
     }
 
     // The return value below ultimately reflects whether or not
@@ -525,261 +555,6 @@ extension PPU {
         }
 
         return redrawScreen
-    }
-}
-
-extension PPU {
-    private func bytesForTileAt(bankIndex: Int, tileIndex: Int) -> ArraySlice<UInt8> {
-        let startAddress = UInt16((bankIndex * 0x1000) + tileIndex * 16)
-        return self.cartridge!.readTileFromChr(startAddress: startAddress)
-    }
-
-    private func getBackgroundPalette(attributeTable: ArraySlice<UInt8>,
-                                      tileX: Int,
-                                      tileY: Int) -> [NESColor] {
-        let attributeTableIndex = ((tileY / 4) * 8) + (tileX / 4)
-        let attributeByte = attributeTable[attributeTable.startIndex + attributeTableIndex]
-
-        let paletteIndex = switch ((tileX % 4) / 2, (tileY % 4) / 2) {
-        case (0, 0):
-            attributeByte & 0b0000_0011
-        case (1, 0):
-            (attributeByte >> 2) & 0b0000_0011
-        case (0, 1):
-            (attributeByte >> 4) & 0b0000_0011
-        case (1, 1):
-            (attributeByte >> 6) & 0b0000_0011
-        default:
-            fatalError("Whoops! We should never get here!")
-        }
-
-        let paletteStartIndex = Int((paletteIndex * 4) + 1)
-        return [
-            0,
-            paletteStartIndex,
-            paletteStartIndex + 1,
-            paletteStartIndex + 2,
-        ].map { index in
-            NESColor.systemPalette[Int(self.paletteTable[index])]
-        }
-    }
-
-    private func setColorAt(x: Int, y: Int, in screenBuffer: inout [NESColor], to color: NESColor) {
-        screenBuffer[Self.width * y + x] = color
-    }
-
-    private func drawBackgroundColor(to screenBuffer: inout [NESColor]) {
-        let backgroundColor = NESColor.systemPalette[Int(self.paletteTable[0])]
-        for y in 0 ..< Self.height {
-            for x in 0 ..< Self.width {
-                self.setColorAt(x: x, y: y, in: &screenBuffer, to: backgroundColor)
-            }
-        }
-    }
-
-    private func drawBackgroundTile(to screenBuffer: inout [NESColor],
-                                    attributeTable: ArraySlice<UInt8>,
-                                    viewPort: ViewPort,
-                                    tileIndex: Int,
-                                    tileX: Int,
-                                    tileY: Int,
-                                    shiftX: Int,
-                                    shiftY: Int) {
-        let bankIndex = self.controllerRegister[.backgroundPatternBankIndex] ? 1 : 0
-        let tileBytes = bytesForTileAt(bankIndex: bankIndex, tileIndex: tileIndex)
-        let backgroundPalette = self.getBackgroundPalette(attributeTable: attributeTable,
-                                                          tileX: tileX,
-                                                          tileY: tileY)
-
-        for (y, var (firstByte, secondByte)) in zip(tileBytes.prefix(8), tileBytes.suffix(8)).enumerated() {
-            for x in (0 ... 7).reversed() {
-                let backgroundColorIndex = Int((secondByte & 0x01) << 1 | (firstByte & 0x01))
-                firstByte >>= 1
-                secondByte >>= 1
-
-                if backgroundColorIndex == 0 {
-                    // Transparent pixel!
-                    continue
-                }
-
-                let backgroundColor = backgroundPalette[backgroundColorIndex]
-                let pixelX = tileX * 8 + x
-                let pixelY = tileY * 8 + y
-
-                if pixelX >= viewPort.startX && pixelX < viewPort.endX &&
-                    pixelY >= viewPort.startY && pixelY < viewPort.endY {
-                    self.setColorAt(x: (pixelX + shiftX), y: (pixelY + shiftY), in: &screenBuffer, to: backgroundColor)
-                }
-            }
-        }
-    }
-
-    private func drawNametable(to screenBuffer: inout [NESColor],
-                               nametable: ArraySlice<UInt8>,
-                               viewPort: ViewPort,
-                               shiftX: Int,
-                               shiftY: Int) {
-        let attributeTable = nametable[(nametable.startIndex + Self.attributeTableOffset)...]
-
-        for i in 0 ..< Self.attributeTableOffset {
-            let tileIndex = Int(nametable[nametable.startIndex + i])
-            let tileX = (i % 32)
-            let tileY = (i / 32)
-
-            self.drawBackgroundTile(to: &screenBuffer,
-                                    attributeTable: attributeTable,
-                                    viewPort: viewPort,
-                                    tileIndex: tileIndex,
-                                    tileX: tileX,
-                                    tileY: tileY,
-                                    shiftX: shiftX,
-                                    shiftY: shiftY)
-        }
-    }
-
-    public func drawBackgroundTiles(to screenBuffer: inout [NESColor]) {
-        let scrollX = Int(self.scrollRegister.scrollX)
-        let scrollY = Int(self.scrollRegister.scrollY)
-
-        let (mainNametable, secondaryNametable) = switch (self.cartridge!.mirroring, self.controllerRegister.nametableAddress()) {
-        case (Mirroring.vertical, 0x2000),
-            (Mirroring.vertical, 0x2800),
-            (Mirroring.horizontal, 0x2000),
-            (Mirroring.horizontal, 0x2400):
-            (self.vram[0x0000 ..< 0x0400], self.vram[0x0400 ..< 0x0800])
-        case (Mirroring.vertical, 0x2400),
-            (Mirroring.vertical, 0x2C00),
-            (Mirroring.horizontal, 0x2800),
-            (Mirroring.horizontal, 0x2C00):
-            (self.vram[0x0400 ..< 0x0800], self.vram[0x0000 ..< 0x0400])
-        default:
-            fatalError("Unsupported mirroring type: \(self.cartridge!.mirroring)")
-        }
-
-        let mainViewPort = ViewPort(startX: scrollX, startY: scrollY, endX: Self.width, endY: Self.height)
-        self.drawNametable(to: &screenBuffer,
-                           nametable: mainNametable,
-                           viewPort: mainViewPort,
-                           shiftX: -scrollX,
-                           shiftY: -scrollY)
-
-        if scrollX > 0 {
-            let secondaryViewPort = ViewPort(startX: 0, startY: 0, endX: scrollX, endY: Self.height)
-            self.drawNametable(to: &screenBuffer,
-                               nametable: secondaryNametable,
-                               viewPort: secondaryViewPort,
-                               shiftX: Self.width - scrollX,
-                               shiftY: 0)
-        } else if scrollY > 0 {
-            let secondaryViewPort = ViewPort(startX: 0, startY: 0, endX: Self.width, endY: scrollY)
-            self.drawNametable(to: &screenBuffer,
-                               nametable: secondaryNametable,
-                               viewPort: secondaryViewPort,
-                               shiftX: 0,
-                               shiftY: Self.height - scrollY)
-        }
-    }
-
-    private func getSpritePalette(paletteIndex: Int) -> [NESColor] {
-        // NOTA BENE: The sprite palettes occupy the _upper_ 16 bytes
-        // of the palette table, which is why the offset below is 0x11
-        // and not 0x01.
-        let paletteStartIndex = Int(0x11 + (paletteIndex * 4))
-        return [
-            0,
-            paletteStartIndex,
-            paletteStartIndex + 1,
-            paletteStartIndex + 2,
-        ].map { index in
-            NESColor.systemPalette[Int(self.paletteTable[index])]
-        }
-    }
-
-    // This function inspects the fifth bit of the tile attributes for each sprite
-    // in the OAM data, and separates out which ones should be rendered behind the
-    // background tiles and which should be drawn in front. It returns a tuple
-    // of indices into the OAM data array.
-    private func getSpriteIndices() -> ([Int], [Int]) {
-        var backgroundSprites: [Int] = []
-        var foregroundSprites: [Int] = []
-        for oamDataIndex in stride(from: 0, to: self.oamRegister.data.count, by: 4) {
-            let tileAttributes = self.oamRegister.data[oamDataIndex + 2]
-            let spriteInBack = tileAttributes >> 5 & 1 == 1
-
-            if spriteInBack {
-                backgroundSprites.append(oamDataIndex)
-            } else {
-                foregroundSprites.append(oamDataIndex)
-            }
-        }
-
-        return (backgroundSprites, foregroundSprites)
-    }
-
-    private func drawSprites(to screenBuffer: inout [NESColor],
-                             for indices: [Int]) {
-        // NOTA BENE: We render sprites in reverse order below; ones at
-        // lower indices in the OAM are rendered _after_ ones at higher indices.
-        for oamDataIndex in indices.reversed() {
-            let tileY = Int(self.oamRegister.data[oamDataIndex])
-            let tileIndex = Int(self.oamRegister.data[oamDataIndex + 1])
-            let tileAttributes = self.oamRegister.data[oamDataIndex + 2]
-            let tileX = Int(self.oamRegister.data[oamDataIndex + 3])
-
-            let flipVertical = tileAttributes >> 7 & 1 == 1
-            let flipHorizontal = tileAttributes >> 6 & 1 == 1
-            let paletteIndex = Int(tileAttributes & 0b11)
-
-            let spritePalette = self.getSpritePalette(paletteIndex: paletteIndex)
-            let bankIndex = self.controllerRegister[.spritePatternBankIndex] ? 1 : 0
-            let tileBytes = self.bytesForTileAt(bankIndex: bankIndex, tileIndex: tileIndex)
-
-            for (y, var (firstByte, secondByte)) in zip(tileBytes.prefix(8), tileBytes.suffix(8)).enumerated() {
-                for x in (0 ... 7).reversed() {
-                    let spriteColorIndex = Int((secondByte & 0x01) << 1 | (firstByte & 0x01))
-                    firstByte >>= 1
-                    secondByte >>= 1
-
-                    if spriteColorIndex == 0 {
-                        // Transparent pixel!
-                        continue
-                    }
-
-                    let spriteColor = spritePalette[spriteColorIndex]
-                    let (screenX, screenY) = switch (flipHorizontal, flipVertical) {
-                    case (false, false):
-                        (tileX + x, tileY + y)
-                    case (true, false):
-                        (tileX + 7 - x, tileY + y)
-                    case (false, true):
-                        (tileX + x, tileY + 7 - y)
-                    case (true, true):
-                        (tileX + 7 - x, tileY + 7 - y)
-                    }
-
-                    if screenX >= 0 && screenX < Self.width && screenY >= 0 && screenY < Self.height {
-                        self.setColorAt(x: screenX, y: screenY, in: &screenBuffer, to: spriteColor)
-                    }
-                }
-            }
-        }
-    }
-
-    // We pass screenBuffer as a mutable parameter to avoid copying
-    // and to maximize performance.
-    public func updateScreenBuffer(_ screenBuffer: inout [NESColor]) {
-        // NOTA BENE: This rendering strategy is based on this post on the NESDev forum:
-        //
-        //     https://forums.nesdev.org/viewtopic.php?p=41698#p41698
-        self.drawBackgroundColor(to: &screenBuffer)
-        let (backgroundSpriteIndices, foregroundSpriteIndices) = getSpriteIndices()
-        self.drawSprites(to: &screenBuffer, for: backgroundSpriteIndices)
-        self.drawBackgroundTiles(to: &screenBuffer)
-        self.drawSprites(to: &screenBuffer, for: foregroundSpriteIndices)
-    }
-
-    static public func makeEmptyScreenBuffer() -> [NESColor] {
-        [NESColor](repeating: .black, count: Self.width * Self.height)
     }
 }
 

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -433,15 +433,21 @@ extension PPU {
 
             let tileX = Int(self.oamRegister.data[spriteIndex + 3])
             let tileY = Int(self.oamRegister.data[spriteIndex])
+            let deltaX = x - tileX
+            let deltaY = y - tileY
+
+            guard deltaX >= 0 && deltaY >= 0 else {
+                return nil
+            }
             let (tilePixelX, tilePixelY) = switch (flipHorizontal, flipVertical) {
             case (false, false):
-                ((x - tileX) % 8, (y - tileY) % 8)
+                (deltaX % 8, deltaY % 8)
             case (true, false):
-                (7 - (x - tileX) % 8, (y - tileY) % 8)
+                (7 - deltaX % 8, deltaY % 8)
             case (false, true):
-                ((x - tileX) % 8, 7 - (y - tileY) % 8)
+                (deltaX % 8, 7 - deltaY % 8)
             case (true, true):
-                (7 - (x - tileX) % 8, 7 - (y - tileY) % 8)
+                (7 - deltaX % 8, 7 - deltaY % 8)
             }
 
             let tileBytes = self.bytesForTileAt(bankIndex: bankIndex, tileIndex: tileIndex)

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -63,7 +63,8 @@ import SwiftUI
 
     @objc func runForOneFrame() {
         cpu.executeInstructions(stoppingAfter: .nextFrame)
-        cpu.updateScreenBuffer(&self.screenBuffer)
+//        cpu.updateScreenBuffer(&self.screenBuffer)
+        self.screenBuffer = cpu.bus.ppu.getScreenBuffer()
     }
 
     func handleKey(_ keyPress: KeyPress) -> Bool {

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -63,8 +63,7 @@ import SwiftUI
 
     @objc func runForOneFrame() {
         cpu.executeInstructions(stoppingAfter: .nextFrame)
-//        cpu.updateScreenBuffer(&self.screenBuffer)
-        self.screenBuffer = cpu.bus.ppu.getScreenBuffer()
+        cpu.bus.ppu.getScreenBuffer(&self.screenBuffer)
     }
 
     func handleKey(_ keyPress: KeyPress) -> Bool {

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -63,7 +63,7 @@ import SwiftUI
 
     @objc func runForOneFrame() {
         cpu.executeInstructions(stoppingAfter: .nextFrame)
-        cpu.bus.ppu.getScreenBuffer(&self.screenBuffer)
+        cpu.bus.ppu.updateScreenBuffer(&self.screenBuffer)
     }
 
     func handleKey(_ keyPress: KeyPress) -> Bool {


### PR DESCRIPTION
As the title suggests, the main thrust of this PR is to implement rendering on a per pixel basis instead of per frame. The primary motivation is to make the code more readable; the original code was largely modeled on the tutorial, and the approach that author took was quite opaque at times. It is also hoped that bugs in emulation of certain features of some games can be more easily debugged since we can far more easily see what it happening down to the pixel.

The strategy is fairly simple: iterate over each scanline (y axis), and for each cycle (x axis), and render a pixel at that point. For each pixel, we need to compute in order:

* whether there is a foreground sprite at that point with an opaque color
* barring that, does the background tile at that point have an opaque color
* barring that, whether there is a _background_ sprite at that point with an opaque color
* barring all the above, select the background color associated with palette index 0

In addition, there were a few optimizations, including:

* using double buffering for swapping the screen into place after it is completely drawn
* wherever possible, avoid creating and returning arrays of objects from functions that are called frequently
* caching of the first eight sprites per each line to avoid searching through the entire sprite array for each pixel