### PR TITLE
Properly support games that use 8x16 sprites

### DIFF
--- a/happiNESs/ControllerRegister.swift
+++ b/happiNESs/ControllerRegister.swift
@@ -38,7 +38,7 @@ public struct ControllerRegister: OptionSet {
     public static let vramAddressIncrement = Self(rawValue: 1 << 2)
     public static let spritePatternBankIndex = Self(rawValue: 1 << 3)
     public static let backgroundPatternBankIndex = Self(rawValue: 1 << 4)
-    public static let spriteSize = Self(rawValue: 1 << 5)
+    public static let spritesAre8x16 = Self(rawValue: 1 << 5)
     public static let masterSlaveSelect = Self(rawValue: 1 << 6)
     public static let generateNmi = Self(rawValue: 1 << 7)
 


### PR DESCRIPTION
I only recently figured out that games like Gradius, Castlevania, and even Galaga use 8x16 sprites, which explains why I only saw half of the sprites, or sprites were otherwise only partially rendered, while playing them in my emulator. And so this PR introduces changes to support such sprites, making games like them actually playable. The following changes were made:

* New computed properties for sprite and tile width and height to centralize magic numbers
* `bytesForTileAt()` now takes a bank index instead of a `ControllerRegister` instance for more general usage, namely because 8x16 sprites 
* `cacheSpriteIndices()` was updated to consider the height of both 8x8 and 8x16 sprites when selecting sprites per each scanline
* `getSpriteColor()` does the most work for 8x16 sprites, now determining:
  * the pixel x and y coordinates within the tile, taking into account the height of such sprites, as well as the horizontal and vertical flip bits
  * the tile index, which is dependent on the tile index byte, but is formed from its first seven bits, using them as is for the top tile, but that value plus one for the bottom tile
  * the bank index, which is obtained from the last bit of the tile index byte not from `ControllerRegister`
  * the color index, needs to use the correct tile index as well as adjust the y value passed in when handling the bottom tile