### PR TITLE
Cache all the things

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		8763D06C2C39E528006C1B4F /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06B2C39E528006C1B4F /* Screen.swift */; };
 		8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06D2C3A340C006C1B4F /* Tracing.swift */; };
 		877E970B2C7E4716007513B5 /* Joypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E970A2C7E4716007513B5 /* Joypad.swift */; };
+		878C69732CAA424400DA9BD4 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878C69722CAA424400DA9BD4 /* Address.swift */; };
 		878D81442C7FEE3B0076ED30 /* image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 878D81432C7FEE3B0076ED30 /* image.xcassets */; };
 		878D81452C7FEE3B0076ED30 /* image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 878D81432C7FEE3B0076ED30 /* image.xcassets */; };
 		878D81472C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
@@ -121,6 +122,7 @@
 		8763D06B2C39E528006C1B4F /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		8763D06D2C3A340C006C1B4F /* Tracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracing.swift; sourceTree = "<group>"; };
 		877E970A2C7E4716007513B5 /* Joypad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joypad.swift; sourceTree = "<group>"; };
+		878C69722CAA424400DA9BD4 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
@@ -213,9 +215,11 @@
 			children = (
 				8744B1752C1CB9B3001B44B5 /* happiNESs.h */,
 				8744B1762C1CB9B3001B44B5 /* happiNESs.docc */,
+				878C69722CAA424400DA9BD4 /* Address.swift */,
 				8744B18C2C1CB9F4001B44B5 /* AddressingMode.swift */,
 				871F62312C6314C900132962 /* AddressRegister.swift */,
 				8719320F2C372F6900A73C22 /* Bus.swift */,
+				871932132C3798B400A73C22 /* Cartridge.swift */,
 				871F62352C65631F00132962 /* ControllerRegister.swift */,
 				8744B1902C1CC0C4001B44B5 /* CPU.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
@@ -229,7 +233,6 @@
 				8744B18E2C1CBB46001B44B5 /* Opcode.swift */,
 				871F622F2C62FE9E00132962 /* PPU.swift */,
 				87184D042C7028F10003D090 /* PPUStatusRegister.swift */,
-				871932132C3798B400A73C22 /* Cartridge.swift */,
 				87184D0B2C7522B80003D090 /* ScrollRegister.swift */,
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
 				8763D06D2C3A340C006C1B4F /* Tracing.swift */,
@@ -414,6 +417,7 @@
 				8744B1912C1CC0C4001B44B5 /* CPU.swift in Sources */,
 				871F62362C65631F00132962 /* ControllerRegister.swift in Sources */,
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
+				878C69732CAA424400DA9BD4 /* Address.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
 				87D265152C9146F400C143B1 /* ViewPort.swift in Sources */,
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,

--- a/happiNESs/Address.swift
+++ b/happiNESs/Address.swift
@@ -21,15 +21,19 @@ typealias Address = UInt16
 //  +++----------------- fine y of the current tile
 //
 // The subscript function in Address plucks out the desired bits (as a UInt8)
-// based on the bit mask passed in.
+// based on the bit mask passed in. (Note that this only works because none of
+// of the bit masks exceeds eight bits.)
 enum AddressBitMask: Address {
-    case fineY     = 0b0111_0000_0000_0000
-    case nametable = 0b0000_1100_0000_0000
-    case coarseY   = 0b0000_0011_1110_0000
-    case coarseX   = 0b0000_0000_0001_1111
+    case fineY      = 0b0111_0000_0000_0000
+    case nametable  = 0b0000_1100_0000_0000
+    case coarseY    = 0b0000_0011_1110_0000
+    case coarseX    = 0b0000_0000_0001_1111
 
-    case highByte  = 0b0011_1111_0000_0000
-    case lowByte   = 0b0000_0000_1111_1111
+    case highByte   = 0b0011_1111_0000_0000
+    case lowByte    = 0b0000_0000_1111_1111
+
+    case nametableY = 0b0000_1000_0000_0000
+    case nametableX = 0b0000_0100_0000_0000
 }
 
 extension Address {

--- a/happiNESs/Address.swift
+++ b/happiNESs/Address.swift
@@ -1,0 +1,50 @@
+//
+//  Address.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 9/29/24.
+//
+
+typealias Address = UInt16
+
+// During the rendering phase, the shared address field in the PPU
+// has the following structure:
+//
+// 0yyy nnYY YYYX XXXX
+//  ||| |||| |||| ||||
+//  ||| |||| |||+-++++-- coarse x, or the x coordinate of the current tile
+//  ||| |||| |||
+//  ||| ||++-+++-------- course y, or the y coordinate of the current tile
+//  ||| ||
+//  ||| ++-------------- nametable index
+//  |||
+//  +++----------------- fine y of the current tile
+//
+// The subscript function in Address plucks out the desired bits (as a UInt8)
+// based on the bit mask passed in.
+enum AddressBitMask: Address {
+    case fineY     = 0b0111_0000_0000_0000
+    case nametable = 0b0000_1100_0000_0000
+    case coarseY   = 0b0000_0011_1110_0000
+    case coarseX   = 0b0000_0000_0001_1111
+}
+
+extension Address {
+    private func getBits(using bitMask: AddressBitMask) -> UInt8 {
+        UInt8((self & bitMask.rawValue) >> bitMask.rawValue.trailingZeroBitCount)
+    }
+
+    mutating private func setBits(using bitMask: AddressBitMask, newBits: UInt8) {
+        let shiftAmount = bitMask.rawValue.trailingZeroBitCount
+        self = (self & ~(bitMask.rawValue)) | Self(newBits << shiftAmount)
+    }
+
+    subscript(index: AddressBitMask) -> UInt8 {
+        get {
+            self.getBits(using: index)
+        }
+        set {
+            self.setBits(using: index, newBits: newValue)
+        }
+    }
+}

--- a/happiNESs/Address.swift
+++ b/happiNESs/Address.swift
@@ -27,6 +27,9 @@ enum AddressBitMask: Address {
     case nametable = 0b0000_1100_0000_0000
     case coarseY   = 0b0000_0011_1110_0000
     case coarseX   = 0b0000_0000_0001_1111
+
+    case highByte  = 0b0011_1111_0000_0000
+    case lowByte   = 0b0000_0000_1111_1111
 }
 
 extension Address {

--- a/happiNESs/Address.swift
+++ b/happiNESs/Address.swift
@@ -34,9 +34,10 @@ extension Address {
         UInt8((self & bitMask.rawValue) >> bitMask.rawValue.trailingZeroBitCount)
     }
 
-    mutating private func setBits(using bitMask: AddressBitMask, newBits: UInt8) {
+    mutating private func setBits(using bitMask: AddressBitMask, bits: UInt8) {
         let shiftAmount = bitMask.rawValue.trailingZeroBitCount
-        self = (self & ~(bitMask.rawValue)) | Self(newBits << shiftAmount)
+        let maskedBits = (Self(bits) << shiftAmount) & bitMask.rawValue
+        self = (self & ~(bitMask.rawValue)) | maskedBits
     }
 
     subscript(index: AddressBitMask) -> UInt8 {
@@ -44,7 +45,7 @@ extension Address {
             self.getBits(using: index)
         }
         set {
-            self.setBits(using: index, newBits: newValue)
+            self.setBits(using: index, bits: newValue)
         }
     }
 }

--- a/happiNESs/AddressRegister.swift
+++ b/happiNESs/AddressRegister.swift
@@ -7,7 +7,7 @@
 
 public struct AddressRegister {
     private var address: UInt16
-    private var highPointer: Bool
+    public var highPointer: Bool
 }
 
 extension AddressRegister {

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -653,6 +653,43 @@ extension PPU {
         self.currentTileData |= UInt64(newTileData)
     }
 
+    mutating private func incrementX() {
+        if self.currentSharedAddress[.coarseX] == 0b1_1111 {
+            // Reset coarse X
+            self.currentSharedAddress[.coarseX] = 0b0_0000
+            // Toggle horizontal nametable
+            self.currentSharedAddress[.nametable] ^= 0b01
+        } else {
+            // Just increment coarse X
+            self.currentSharedAddress[.coarseX] += 0b0_0001
+        }
+    }
+
+    mutating private func incrementY() {
+        if self.currentSharedAddress[.fineY] == 0b111 {
+            // Reset fine Y
+            self.currentSharedAddress[.fineY] = 0b000
+
+            if self.currentSharedAddress[.coarseY] == 0b1_1110 {
+                // Reset coarse Y
+                self.currentSharedAddress[.coarseY] = 0b0_0000
+                // Toggle vertical nametable
+                self.currentSharedAddress[.nametable] ^= 0b10
+            } else if self.currentSharedAddress[.coarseY] == 0b1_1111 {
+                // ACHTUNG! How would we ever get to this branch?
+                //
+                // Reset coarse Y
+                self.currentSharedAddress[.coarseY] = 0b0_0000
+            } else {
+                // Just increment coarse Y
+                self.currentSharedAddress[.coarseY] += 0b0_0001
+            }
+        } else {
+            // Just increment fine Y
+            self.currentSharedAddress[.fineY] += 0b001
+        }
+    }
+
     private func getSpriteColor(spriteIndex: Int,
                                 x: Int,
                                 y: Int) -> NESColor? {

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -73,6 +73,8 @@ public struct PPU {
 
     private var screenBuffer: [NESColor] = [NESColor](repeating: NESColor.black, count: Self.width * Self.height)
     private var spriteIndicesForCurrentScanline: ArraySlice<Int> = []
+    private var currentVramAddress: UInt16 = 0
+    private var currentNametableByte: UInt8 = 0
 
     public init() {
         self.internalDataBuffer = 0x00
@@ -416,6 +418,12 @@ extension PPU {
     var tileHeight: Int { 8 }
     var spriteWidth: Int { tileWidth }
     var spriteHeight: Int { self.controllerRegister[.spritesAre8x16] ? tileHeight * 2 : tileHeight }
+
+    var tileAddress: UInt16 { 0x2000 | (0x0FFF & self.currentVramAddress) }
+
+    mutating private func fetchNametableByte() {
+        self.currentNametableByte = self.vram[vramIndex(from: self.currentVramAddress)]
+    }
 
     private func getSpriteColor(spriteIndex: Int,
                                 x: Int,

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -855,6 +855,40 @@ extension PPU {
         return (y == self.scanline) && x <= cycles && self.maskRegister[.showSprites]
     }
 
+    mutating private func updateCaches() {
+        if self.scanline < Self.height || self.scanline == Self.scanlinesPerFrame {
+            if self.cycles < Self.width || (self.cycles >= 320 && self.cycles <= 335) {
+                switch self.cycles % 8 {
+                case 1:
+                    self.cacheNametableByte()
+                case 3:
+                    self.cachePaletteIndex()
+                case 5:
+                    self.cacheLowTileByte()
+                case 7:
+                    self.cacheHighTileByte()
+                case 0:
+                    self.incrementX()
+                    self.cacheTileData()
+                default:
+                    break
+                }
+            }
+
+            if self.cycles == 255 {
+                self.incrementY()
+            }
+
+            if self.cycles == 256 {
+                self.copyX()
+            }
+        }
+
+        if self.scanline == Self.scanlinesPerFrame && self.cycles >= 279 && self.cycles <= 303 {
+            self.copyY()
+        }
+    }
+
     // The return value below ultimately reflects whether or not
     // we need to redraw the screen.
     mutating func tick(cpuCycles: Int) -> Bool {

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -653,6 +653,17 @@ extension PPU {
         self.currentTileData |= UInt64(newTileData)
     }
 
+    mutating private func copyX() {
+        self.currentSharedAddress[.coarseX] = self.nextSharedAddress[.coarseX]
+        self.currentSharedAddress[.nametableX] = self.nextSharedAddress[.nametableX]
+    }
+
+    mutating private func copyY() {
+        self.currentSharedAddress[.coarseY] = self.nextSharedAddress[.coarseY]
+        self.currentSharedAddress[.fineY] = self.nextSharedAddress[.fineY]
+        self.currentSharedAddress[.nametableY] = self.nextSharedAddress[.nametableY]
+    }
+
     mutating private func incrementX() {
         if self.currentSharedAddress[.coarseX] == 0b1_1111 {
             // Reset coarse X


### PR DESCRIPTION
This PR is another step forward towards properly emulating the NES, specifically that we ultimately want to be able to cache multiple pieces of data during the rendering phase and compute color values based on them, versus computing colors dependent on the live values of multiple pieces of state. There are several motivations for this:

* Caching different data elements to be used later on when computing the color of a pixel is actually more faithful to the way the NES actually functioned.
* Computing color values for pixels, although largely correct, is also inefficient and incurs a performance hit, as many data elements used in those algorithms are computed over and over again on the fly instead of being reused.
* Certain pieces of state, such as the scroll X value, change in the midst of rendering a line of pixels, and so currently the end result is that the HUD for Super Mario Bros. doesn't render properly and even flickers at certain times. Using cached values which are refreshed at the same rate that they are in an actual NES will (hopefully) get rid of such artifacts.

This set of changes is modeled largely on relevant portions of implementations in two codebases, https://github.com/robb/NES.swift and https://github.com/fogleman/nes. The main things are:

* New cached values:
  * `currentSharedAddress`: a `UInt16` which mostly corresponds with the so-called V register in the NES
  * `nextSharedAddress`: a `UInt16` which mostly corresponds with the so-called T register in the NES
  * `currentNametableByte`: a `UInt8` which contains the byte in the current nametable relevant to the current tile
  * `currentPaletteIndex`: also a `UInt8` but is effectively only a two-bit value representing an index into the palette for a given tile
  * `currentLowTileByte`: also a `UInt8` which contains the low byte relevant to the current tile
  * `currentHighTileByte`: also a `UInt8` which contains the high byte relevant to the current tile but 
  * `currentTileData`: a `UInt64` with contains data relevant to the current _and_ next tile
  * `currentFineX`: a `UInt8` but is effectively the three-bit value representing the index of the x-coordinate within the current tile. (Note, that we don't need to cache the current fine Y value separately as it is incorporated into `currentSharedAddress` and can be easily extracted.)

* ... which are updated directly by the following new caching functions:
  * `cacheNametableByte()`
  * `cachePaletteIndex()`
  * `cacheLowTileByte()`
  * `cacheHighTileByte()`
  * `cacheTileData()`
  * `copyX()` and `copyY()`
  * `incrementX()` and `incrementY()`

* ... as well as slightly altered versions of these existing functions:
  * `updateAddress()`: which mostly corresponds with writing to PPUADDR
  * `updateController()`: which mostly corresponds with writing to PPUCTRL
  * `writeScrollByte()`: which mostly corresponds with writing to PPUSCROLL

* The new `updateCaches()` function is what coordinates most of the updates above, and is now wired up to the `tick()` function.

* There is a new type alias, namely `Address`, which centralizes a great deal of the bit-twiddling that is required in many of the new functions above. I have also striven to add detailed comments wherever relevant to help both other readers and `$FUTURE_DANIELLE` to understand the code.

* For now, _none_ of the functions in the call chain in the current `renderPixel()` function utilize _any_ of the caches. This PR merely introduces these new caching strategies but has _no_ effect of the current rendering implementation. The _next_ PR will be incorporate the new caches.

NOTA BENE: It should be made clear up front that up until this PR, a good deal of the design of this emulator was based on the tutorial that I had originally started following, https://bugzmanov.github.io/nes_ebook/. However, this codebase has been significantly veering away from that design with the last several PRs, and I think I've reached the point where the modeling of PPU registers needs to be revisited. However, in the interest of preserving current behavior and minimizing regressions, I am taking an iterative approach, slowing introducing new (and hopefully improved) code while keeping as much of the old code as possible to be able to play games as I have been able to previously.