### PR TITLE
OMFG I FIXED THE HUD

### DIFF
--- a/happiNESs/PPU+caching.swift
+++ b/happiNESs/PPU+caching.swift
@@ -200,13 +200,15 @@ extension PPU {
     mutating public func cacheSpriteIndices() {
         let allSpriteIndices = stride(from: 0, to: self.oamRegister.data.count, by: 4)
         self.spriteIndicesForCurrentScanline = allSpriteIndices.filter({ oamIndex in
-            let tileY = Int(self.oamRegister.data[oamIndex])
+            // ACHTUNG! Note that the value in OAM is one less than the actual Y value!
+            //
+            //    https://www.nesdev.org/wiki/PPU_OAM#Byte_0
+            let tileY = Int(self.oamRegister.data[oamIndex]) + 1
 
             // The sprite height property takes into account whether or not
             // it is 8x8 or 8x16, and so we need to test to see if the current
             // scanline intersects it anywhere vertically.
-            let deltaY = self.spriteHeight - 1
-            if self.scanline >= tileY && self.scanline <= tileY + deltaY {
+            if self.scanline >= tileY && self.scanline < tileY + self.spriteHeight {
                 return true
             }
 
@@ -286,7 +288,7 @@ extension PPU {
             }
         }
 
-        if self.isPreLine && self.isCopyVerticalScrollCycle {
+        if self.isPreRenderLine && self.isCopyVerticalScrollCycle {
             self.copyY()
         }
 

--- a/happiNESs/PPU+tracing.swift
+++ b/happiNESs/PPU+tracing.swift
@@ -23,10 +23,12 @@ extension PPU {
 
             let flipVertical = tileAttributes >> 7 & 1 == 1
             let flipHorizontal = tileAttributes >> 6 & 1 == 1
+            let isBackground = tileAttributes >> 5 & 1 == 1
             let paletteIndex = Int(tileAttributes & 0b11)
 
             print("- \(oamDataIndex / 4):", tileIndex, "@ \(tileX),\(tileY)",
                   (flipVertical ? "vflip" : ""), (flipHorizontal ? "hflip" : ""),
+                  (isBackground ? "bg" : ""),
                   "colored", paletteIndex)
         }
     }


### PR DESCRIPTION
So... for weeks I've been trying to get the HUD in Super Mario Bros. to stop from scrolling... and mostly that's had to do with improper sprite zero hit detection. The one I had been using all along was the one from the Rust tutorial that I had dutifully followed for most of the beginning of this project but soon realized was wrong. However, whenever I turned on the proper logic, which should set the flag when an actual pixel from sprite zero overlaps with one from a background tile, I wound up with a HUD that mostly rendered properly and remained fixed except for the very first line:

![image](https://github.com/user-attachments/assets/f19b3592-e917-48c9-9654-2cce9c9793f0)

I explain an entire thought process here, https://tech.lgbt/@quephird/113284970570758119, but the gist of it is that there actually were no other problems with my caching or rendering logic... other than the fact that _the Y value in the OAM attribute for each sprite is one less than the actual Y value_. This is very very subtly stated in the NESDev wiki, https://www.nesdev.org/wiki/PPU_OAM#Byte_0, but never mentioned in the tutorial.

So... the main change introduced in this PR was adjustment to two places in the code from before: one where I select sprites to cache per each visible scanline, and the other where I compute the color for a specific pixel in a sprite correspondent with an (X, Y) value. Other changes include:

* A tiny change in the PPU tracer to include whether or not a sprite has background priority
* Some renaming of computed properties for improved clarity
* Some rearrangement of the logic in `PPU.tick()` to be more in alignment with two other emulator codebases that I've been looking at for sanity checking. 
