### PR TITLE
Streamline sprite caching

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B18E2C1CBB46001B44B5 /* Opcode.swift */; };
 		8744B1912C1CC0C4001B44B5 /* CPU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1902C1CC0C4001B44B5 /* CPU.swift */; };
 		8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1922C1D6D59001B44B5 /* StatusRegister.swift */; };
+		874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51912CB9B51C00B12037 /* CachedSprite.swift */; };
 		8763D0652C386A17006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0662C386A2E006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0682C39B61F006C1B4F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0672C39B61F006C1B4F /* Helpers.swift */; };
@@ -126,6 +127,7 @@
 		8744B18E2C1CBB46001B44B5 /* Opcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Opcode.swift; sourceTree = "<group>"; };
 		8744B1902C1CC0C4001B44B5 /* CPU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPU.swift; sourceTree = "<group>"; };
 		8744B1922C1D6D59001B44B5 /* StatusRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusRegister.swift; sourceTree = "<group>"; };
+		874F51912CB9B51C00B12037 /* CachedSprite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedSprite.swift; sourceTree = "<group>"; };
 		8763D0642C386A17006C1B4F /* snake.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = snake.nes; sourceTree = "<group>"; };
 		8763D0672C39B61F006C1B4F /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 				878C69722CAA424400DA9BD4 /* Address.swift */,
 				8744B18C2C1CB9F4001B44B5 /* AddressingMode.swift */,
 				8719320F2C372F6900A73C22 /* Bus.swift */,
+				874F51912CB9B51C00B12037 /* CachedSprite.swift */,
 				871932132C3798B400A73C22 /* Cartridge.swift */,
 				871F62352C65631F00132962 /* ControllerRegister.swift */,
 				8744B1902C1CC0C4001B44B5 /* CPU.swift */,
@@ -436,6 +439,7 @@
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
 				878C69732CAA424400DA9BD4 /* Address.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
+				874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */,
 				87D265152C9146F400C143B1 /* ViewPort.swift in Sources */,
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,

--- a/happiNESs/CachedSprite.swift
+++ b/happiNESs/CachedSprite.swift
@@ -1,0 +1,13 @@
+//
+//  Sprite.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/11/24.
+//
+
+public struct CachedSprite {
+    public var data: UInt32
+    public var tileX: Int
+    public var backgroundPriority: Bool
+    public var index: Int
+}

--- a/happiNESs/PPU+caching.swift
+++ b/happiNESs/PPU+caching.swift
@@ -360,7 +360,7 @@ extension PPU {
         }
     }
 
-    mutating public func updateCaches() {
+    mutating public func cacheBackgroundTiles() {
         if self.isRenderLine && self.isFetchCycle {
             self.currentAndNextTileData <<= 4
 

--- a/happiNESs/PPU+rendering.swift
+++ b/happiNESs/PPU+rendering.swift
@@ -139,15 +139,31 @@ extension PPU {
     }
 
     private func getSpriteColor(x: Int, y: Int) -> (color: NESColor, index: Int, backgroundPriority: Bool)? {
-        for index in self.spriteIndicesForCurrentScanline {
-            if let color = self.getSpriteColor(spriteIndex: index,
-                                               x: x,
-                                               y: y) {
-                let tileAttributes = self.oamRegister.data[index + 2]
-                let backgroundPriority = tileAttributes >> 5 & 1 == 1
-                return (color, index, backgroundPriority)
+        for sprite in self.currentSprites {
+            let spritePixelX = self.cycles - sprite.tileX
+            if spritePixelX < 0 || spritePixelX > 7 {
+                continue
             }
+
+            let nibbleIndex = 7 - spritePixelX
+            let paletteIndex = Int((sprite.data >> (nibbleIndex * 4)) & 0b0000_1111) + 0x10
+            if paletteIndex.isMultiple(of: 4) {
+                continue
+            }
+
+            let color = NESColor.systemPalette[Int(self.paletteTable[paletteIndex])]
+            return (color, sprite.index, sprite.backgroundPriority)
         }
+
+//        for index in self.spriteIndicesForCurrentScanline {
+//            if let color = self.getSpriteColor(spriteIndex: index,
+//                                               x: x,
+//                                               y: y) {
+//                let tileAttributes = self.oamRegister.data[index + 2]
+//                let backgroundPriority = tileAttributes >> 5 & 1 == 1
+//                return (color, index, backgroundPriority)
+//            }
+//        }
 
         return nil
     }

--- a/happiNESs/PPU+rendering.swift
+++ b/happiNESs/PPU+rendering.swift
@@ -6,51 +6,6 @@
 //
 
 extension PPU {
-    private func bytesForTileAt(bankIndex: Int,
-                                tileIndex: Int) -> ArraySlice<UInt8> {
-        let bankAddressStart = UInt16(bankIndex * 0x1000)
-        let startAddress = bankAddressStart + UInt16(tileIndex * 16)
-        return self.cartridge!.readTileFromChr(startAddress: startAddress)
-    }
-
-    private func getColorFromPalette(baseIndex: Int, entryIndex: Int) -> NESColor? {
-        guard !entryIndex.isMultiple(of: 4) else {
-            return nil
-        }
-
-        let paletteIndex = baseIndex + entryIndex
-        return NESColor.systemPalette[Int(self.paletteTable[paletteIndex])]
-    }
-
-    private func getTileColorIndex(bankIndex: Int,
-                                   tileIndex: Int,
-                                   tilePixelX: Int,
-                                   tilePixelY: Int) -> Int {
-        let tileBytes = self.bytesForTileAt(bankIndex: bankIndex,
-                                            tileIndex: tileIndex)
-        let firstByte = tileBytes[tileBytes.startIndex + tilePixelY]
-        let secondByte = tileBytes[tileBytes.startIndex + tilePixelY + 8]
-        let bitMask: UInt8 = 0b1000_0000 >> tilePixelX
-        let firstBit = firstByte & bitMask > 0 ? 0b01 : 0b00
-        let secondBit = secondByte & bitMask > 0 ? 0b10 : 0b00
-        return secondBit | firstBit
-    }
-
-    private func getBackgroundTileColor(x: Int, y: Int) -> NESColor? {
-        let tileData = self.currentTileData
-        let pixelData = tileData >> ((7 - self.currentFineX) * 4)
-        let colorIndex = Int(pixelData & 0x0F)
-        return colorIndex.isMultiple(of: 4) ? nil : NESColor.systemPalette[Int(self.paletteTable[colorIndex])]
-    }
-
-    private func getSpritePalette(paletteIndex: Int, colorIndex: Int) -> NESColor? {
-        // NOTA BENE: The sprite palettes occupy the _upper_ 16 bytes
-        // of the palette table, which is why the offset below is 0x10
-        // and not 0x00.
-        let paletteStartIndex = Int(0x10 + (paletteIndex * 4))
-        return getColorFromPalette(baseIndex: paletteStartIndex, entryIndex: colorIndex)
-    }
-
     var tileWidth: Int {
         8
     }
@@ -64,88 +19,29 @@ extension PPU {
         self.controllerRegister[.spritesAre8x16] ? tileHeight * 2 : tileHeight
     }
 
-    private func getSpriteColor(spriteIndex: Int,
-                                x: Int,
-                                y: Int) -> NESColor? {
-        let tileAttributes = self.oamRegister.data[spriteIndex + 2]
-        let tileX = Int(self.oamRegister.data[spriteIndex + 3])
-        // Determine if the x coordinate falls inside the sprite
-        guard x >= tileX && x < tileX + self.spriteWidth else {
-            return nil
-        }
-        // ACHTUNG! Note that the value in OAM is one less than the actual Y value!
-        //
-        //    https://www.nesdev.org/wiki/PPU_OAM#Byte_0
-        let tileY = Int(self.oamRegister.data[spriteIndex]) + 1
-
-        let flipVertical = tileAttributes >> 7 & 1 == 1
-        let flipHorizontal = tileAttributes >> 6 & 1 == 1
-        let paletteIndex = Int(tileAttributes & 0b11)
-
-        let deltaX = x - tileX
-        let deltaY = y - tileY
-        guard deltaX >= 0 && deltaY >= 0 else {
-            // Sprite is at least partially off screen
-            return nil
-        }
-
-        let spritePixelX = flipHorizontal ? (spriteWidth - 1) - deltaX % spriteWidth : deltaX % spriteWidth
-        let spritePixelY = flipVertical ? (spriteHeight - 1) - deltaY % spriteHeight : deltaY % spriteHeight
-
-        let tileIndexByte = self.oamRegister.data[spriteIndex + 1]
-        let topTileIndex: Int
-        let bankIndex: Int
-        if self.controllerRegister[.spritesAre8x16] {
-            // The bits in the tile index byte are arranged like 'tttttttb'.
-            // The first seven bits form the base for the tile index, where the
-            // top half of the sprite has tile index ttttttt0, and the bottom
-            // half has index ttttttt1. The last bit indicates which tile bank
-            // to use to fetch the tile; 0 means the starting address should be
-            // 0x0000, 1 means 0x1000. See the following for more details:
-            //
-            //     https://www.nesdev.org/wiki/PPU_OAM#Byte_1
-            bankIndex = Int(tileIndexByte & 0b0000_0001)
-            topTileIndex = Int(tileIndexByte & 0b1111_1110)
-        } else {
-            bankIndex = self.controllerRegister[.spritePatternBankIndex] ? 1 : 0
-            topTileIndex = Int(tileIndexByte)
-        }
-
-        let colorIndex: Int
-        // The following test effectively checks to see if we're sampling
-        // from the top tile or the the bottom tile for an 8x16 sprite.
-        // If the sprite's y value is larger than the height of a tile, then
-        // we know that we're dealing with the bottom tile; otherwise, we're
-        // still in the top tile. If we're handling an 8x8 sprite, then it's
-        // as if we're handling the top tile of an 8x16 sprite.
-        if spritePixelY < tileHeight {
-            colorIndex = self.getTileColorIndex(bankIndex: bankIndex,
-                                                tileIndex: topTileIndex,
-                                                tilePixelX: spritePixelX,
-                                                tilePixelY: spritePixelY)
-        } else {
-            // If we're here, then we know that we're handling the bottom tile
-            // in which case its index is one more than that for the top tile.
-            // Also, the tile's y coordinate needs to be adjusted to fall inside
-            // the tile.
-            colorIndex = self.getTileColorIndex(bankIndex: bankIndex,
-                                                tileIndex: topTileIndex + 1,
-                                                tilePixelX: spritePixelX,
-                                                tilePixelY: spritePixelY % tileHeight)
-        }
-
-        let color = self.getSpritePalette(paletteIndex: paletteIndex, colorIndex: colorIndex)
-        return color
+    private func getBackgroundTileColor(x: Int, y: Int) -> NESColor? {
+        let tileData = self.currentTileData
+        let pixelData = tileData >> ((7 - self.currentFineX) * 4)
+        let colorIndex = Int(pixelData & 0x0F)
+        return colorIndex.isMultiple(of: 4) ? nil : NESColor.systemPalette[Int(self.paletteTable[colorIndex])]
     }
 
     private func getSpriteColor(x: Int, y: Int) -> (color: NESColor, index: Int, backgroundPriority: Bool)? {
+        // Note that `currentSprites` is ordered from left to right by the OAM index,
+        // with the first (zeroth) element being the so-called sprite zero. Furthermore,
+        // the strategy here is to find the first sprite whose pixels intersect with the
+        // current X value _and_ which has a non-transparent color. If we find none,
+        // then we return a nil tuple.
         for sprite in self.currentSprites {
             let spritePixelX = self.cycles - sprite.tileX
+            // Check to see if the current X value is within the current sprite
             if spritePixelX < 0 || spritePixelX > 7 {
                 continue
             }
 
             let nibbleIndex = 7 - spritePixelX
+            // NOTA BENE: The sprite palettes occupy the _upper_ 16 bytes of the palette
+            // tables, which is why we add 0x10 below.
             let paletteIndex = Int((sprite.data >> (nibbleIndex * 4)) & 0b0000_1111) + 0x10
             if paletteIndex.isMultiple(of: 4) {
                 continue
@@ -154,16 +50,6 @@ extension PPU {
             let color = NESColor.systemPalette[Int(self.paletteTable[paletteIndex])]
             return (color, sprite.index, sprite.backgroundPriority)
         }
-
-//        for index in self.spriteIndicesForCurrentScanline {
-//            if let color = self.getSpriteColor(spriteIndex: index,
-//                                               x: x,
-//                                               y: y) {
-//                let tileAttributes = self.oamRegister.data[index + 2]
-//                let backgroundPriority = tileAttributes >> 5 & 1 == 1
-//                return (color, index, backgroundPriority)
-//            }
-//        }
 
         return nil
     }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -36,7 +36,7 @@ public struct PPU {
     public var wRegister: Bool = false
 
     public var cycles: Int
-    public var scanline: UInt16
+    public var scanline: Int
     public var nmiInterrupt: UInt8?
 
     public var screenBuffer: [NESColor] = [NESColor](repeating: NESColor.black, count: Self.width * Self.height)
@@ -49,7 +49,8 @@ public struct PPU {
     public var currentHighTileByte: UInt8 = 0
     public var currentAndNextTileData: UInt64 = 0
     public var currentFineX: UInt8 = 0
-    public var spriteIndicesForCurrentScanline: ArraySlice<Int> = []
+    public var spriteIndicesForCurrentScanline: [Int] = []
+    public var currentSprites: [CachedSprite] = []
 
     public init() {
         self.internalDataBuffer = 0x00

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -152,7 +152,7 @@ public struct PPU {
                     self.renderPixel(x: self.cycles, y: Int(self.scanline))
                 }
 
-                self.updateCaches()
+                self.cacheBackgroundTiles()
 
                 if self.isVisibleLine && self.cycles == 0 {
                     self.cacheSprites()

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -149,7 +149,7 @@ public struct PPU {
 
             if self.isRenderingEnabled {
                 if self.isVisibleLine && self.isVisibleCycle {
-                    self.renderPixel(x: self.cycles, y: Int(self.scanline))
+                    self.renderPixel()
                 }
 
                 self.cacheBackgroundTiles()

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -49,7 +49,6 @@ public struct PPU {
     public var currentHighTileByte: UInt8 = 0
     public var currentAndNextTileData: UInt64 = 0
     public var currentFineX: UInt8 = 0
-    public var spriteIndicesForCurrentScanline: [Int] = []
     public var currentSprites: [CachedSprite] = []
 
     public init() {
@@ -156,7 +155,7 @@ public struct PPU {
                 self.updateCaches()
 
                 if self.isVisibleLine && self.cycles == 0 {
-                    self.cacheSpriteIndices()
+                    self.cacheSprites()
                 }
             }
 


### PR DESCRIPTION
This PR directly follows up the one in which we cache background tile data, https://github.com/quephird/happiNESs/pull/39; this time we cache sprite data with each visible scanline, and render sprites using that cache. The main changes include the following:

* There is a new struct, `CachedSprite`, which holds four pieces of information relevant to a sprite. 
* `cacheSpriteIndices()` is now `cacheSprites()` and updates the new `currentSprites` field of `PPU`. It still identifies the first eight sprites that intersect with the current scanline, but this time calls a new function `getSpriteData()` to fetch significantly more data, and caches them in an instance of `CachedSprite` not just the sprite index.
* Old functions which computed colors of pixels on the fly are now deleted, but most of the comments in them have been moved to `getSpriteData()` as they are still informative and relevant.
* Multiple functions used in rendering no longer take x and y parameters as they are inferred from current state instead of needing to be passed in.