### PR TITLE
Improve rendering performance

### DIFF
--- a/happiNESs/PPU+rendering.swift
+++ b/happiNESs/PPU+rendering.swift
@@ -82,15 +82,17 @@ extension PPU {
     mutating public func renderPixel() {
         let color = self.getCurrentPixelColor()
         let currentPixelIndex = Self.width * self.scanline + self.cycles
-        self.screenBuffer[currentPixelIndex] = color
+        self.screenBuffer[currentPixelIndex * 3] = color.red
+        self.screenBuffer[(currentPixelIndex * 3) + 1] = color.green
+        self.screenBuffer[(currentPixelIndex * 3) + 2] = color.blue
     }
 
-    static public func makeEmptyScreenBuffer() -> [NESColor] {
-        [NESColor](repeating: .black, count: Self.width * Self.height)
+    static public func makeEmptyScreenBuffer() -> [UInt8] {
+        [UInt8](repeating: 0x00, count: Self.width * Self.height * 3)
     }
 
     // We are double buffering here to maximize performance.
-    mutating public func updateScreenBuffer(_ otherBuffer: inout [NESColor]) {
+    mutating public func updateScreenBuffer(_ otherBuffer: inout [UInt8]) {
         swap(&self.screenBuffer, &otherBuffer)
     }
 }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -39,7 +39,7 @@ public struct PPU {
     public var scanline: Int
     public var nmiInterrupt: UInt8?
 
-    public var screenBuffer: [NESColor] = [NESColor](repeating: NESColor.black, count: Self.width * Self.height)
+    public var screenBuffer: [UInt8] = [UInt8](repeating: 0x00, count: Self.width * Self.height * 3)
 
     // These are all cached values that are refreshed during various stages
     // of the rendering cycle.

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -31,7 +31,7 @@ import SwiftUI
     // really interested in changes to `Console`'s state such that at least of the underlying
     // pixels has changed, namely any of the elements of  `screenBuffer`.
     @ObservationIgnored private var cpu: CPU
-    var screenBuffer: [NESColor] = PPU.makeEmptyScreenBuffer()
+    var screenBuffer: [UInt8] = PPU.makeEmptyScreenBuffer()
 
     internal init() throws {
         let bus = Bus()
@@ -49,7 +49,7 @@ import SwiftUI
         self.cpu.reset()
 
         // We need to do this to avoid keeping around previously registered timers
-        // and having them fire when we load on ROM file after another
+        // and having them fire when we load one ROM file after another
         self.displayTimer?.invalidate()
 
         // This sets up a timer which will call `runForOneFrame()` every time it fires.

--- a/happiNESsApp/ContentView.swift
+++ b/happiNESsApp/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
             Screen(screenBuffer: console.screenBuffer)
             .padding()
             .focusable()
+            .focusEffectDisabled()
             .focused($focused)
             .onAppear {
                 focused = true

--- a/happiNESsApp/Screen.swift
+++ b/happiNESsApp/Screen.swift
@@ -22,29 +22,20 @@ extension CGBitmapInfo {
 struct Screen: View {
     static let width: Int = PPU.width
     static let height: Int = PPU.height
-    static let scale: Double = 2.0
+    static let scale: Double = 3.0
     static let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
     static let bitmapInfo: CGBitmapInfo = [
         CGBitmapInfo(alphaInfo: .none),
         CGBitmapInfo(byteOrderInfo: .orderDefault),
     ]
 
-    var screenBuffer: [NESColor]
+    var screenBuffer: [UInt8]
 
     var body: some View {
-        Canvas {graphicsContext, size in
+        Canvas(opaque: true) {graphicsContext, size in
             graphicsContext.withCGContext { cgContext in
-                // First we have to convert screenBuffer into a bitmap buffer of raw UInt8's
-                var bitmapBuffer = [UInt8]()
-                bitmapBuffer.reserveCapacity(Self.width * Self.height * 3)
-                for color in screenBuffer {
-                    bitmapBuffer.append(color.red)
-                    bitmapBuffer.append(color.green)
-                    bitmapBuffer.append(color.blue)
-                }
-
-                precondition(bitmapBuffer.count == Self.width * Self.height * 3)
-                bitmapBuffer.withUnsafeBytes { bufferPointer in
+                precondition(self.screenBuffer.count == Self.width * Self.height * 3)
+                self.screenBuffer.withUnsafeBytes { bufferPointer in
                     // Then we need to make a provider that instructs CGImage how to read in the bitmap buffer.
                     //
                     // NOTA BENE: bufferPointer.baseAddress will never be null in this context


### PR DESCRIPTION
This PR is an effort to improve performance of the emulator, especially when rendering with pixels scaled up by a factor of three. Weirdly when the app was in focus it ran somewhat slowly, but when either opening the Open ROM... dialog or bringing another app into focus, the emulator ran at top speed _in the background_. After some debugging, it turned out that the problem was the so-called focus ring, namely that it was activated, as evidenced but he blue border around the canvas. Adding the `focusEffectDisabled()` modifier on the top level SwiftUI component made everything render much faster when the app was in focus.

I had originally thought that the problem was due to inefficiencies somewhere in the code, namely where we take the screen buffer, write it to an image, and then write that to the canvas. But that wasn't the source of the problem. Nonetheless, I changed the screen buffer to be an array of `UInt8`s and updated said closure in `Screen`s `Canvas` to use it directly to avoid an extra copy per frame. In doing so, I had to make sure that `renderPixel()` wrote out _three_ `UInt8`s instead of a single `NESColor` to the screen buffer.

For now, the scale factor has been changed to 3.0; in a future PR, we'll try to expose something in the UI to allow the user to specify a scale value from 1.0, 2.0, or 3.0.