### PR TITLE
Improve image fidelity

### DIFF
--- a/happiNESsApp/Screen.swift
+++ b/happiNESsApp/Screen.swift
@@ -23,6 +23,7 @@ struct Screen: View {
     static let width: Int = PPU.width
     static let height: Int = PPU.height
     static let scale: Double = 3.0
+
     static let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
     static let bitmapInfo: CGBitmapInfo = [
         CGBitmapInfo(alphaInfo: .none),
@@ -30,49 +31,35 @@ struct Screen: View {
     ]
 
     var screenBuffer: [UInt8]
+    var image: CGImage {
+        self.screenBuffer.withUnsafeBytes { bufferPointer in
+            // Creates a CFData instance with a copy of the data from the screen buffer
+            let data = CFDataCreate(nil, bufferPointer.baseAddress!, bufferPointer.count)!
+
+            // Make a provider that instructs CGImage how to read in the bitmap buffer.
+            let dataProvider = CGDataProvider(data: data)!
+
+            // Create the actual CGImage using the data provider.
+            return CGImage(width: Self.width,
+                           height: Self.height,
+                           bitsPerComponent: 8,
+                           bitsPerPixel: 8 * 3,
+                           bytesPerRow: Self.width * 3,
+                           space: Self.colorSpace,
+                           bitmapInfo: Self.bitmapInfo,
+                           provider: dataProvider,
+                           decode: nil,
+                           shouldInterpolate: false,
+                           intent: .defaultIntent)!
+        }
+    }
 
     var body: some View {
-        Canvas(opaque: true) {graphicsContext, size in
-            graphicsContext.withCGContext { cgContext in
-                precondition(self.screenBuffer.count == Self.width * Self.height * 3)
-                self.screenBuffer.withUnsafeBytes { bufferPointer in
-                    // Then we need to make a provider that instructs CGImage how to read in the bitmap buffer.
-                    //
-                    // NOTA BENE: bufferPointer.baseAddress will never be null in this context
-                    // Also, we don't need to use an actual closure in when we deallocate the data provider,
-                    // and so don't need to pass in a value for dataInfo to that closure either.
-                    let dataProvider = CGDataProvider(
-                        dataInfo: nil,
-                        data: bufferPointer.baseAddress!,
-                        size: bufferPointer.count,
-                        releaseData: {_, _, _ in })!
-
-                    // Next we need to create the actual CGImage using the data provider.
-                    let image = CGImage(
-                        width: Self.width,
-                        height: Self.height,
-                        bitsPerComponent: 8,
-                        bitsPerPixel: 8 * 3,
-                        bytesPerRow: Self.width * 3,
-                        space: Self.colorSpace,
-                        bitmapInfo: Self.bitmapInfo,
-                        provider: dataProvider,
-                        decode: nil,
-                        shouldInterpolate: false,
-                        intent: .defaultIntent)!
-
-                    // Then we need to set up the graphics context such that the image
-                    // actually starts at the upper left not the bottom left, and doesn't
-                    // wind up being displayed upside down.
-                    cgContext.scaleBy(x: 1, y: -1)
-                    cgContext.translateBy(x: 0, y: -size.height)
-
-                    // Then we draw the image to the graphics context
-                    let drawingRect = CGRect(origin: .zero, size: size)
-                    cgContext.draw(image, in: drawingRect, byTiling: false)
-                }
-            }
-        }
+        Image(self.image,
+              scale: 1/3.0,
+              orientation: .up,
+              label: Text(verbatim: "Screen"))
+        .interpolation(.none)
         .frame(
             width: CGFloat(Self.width) * Self.scale,
             height: CGFloat(Self.height) * Self.scale)

--- a/happiNESsApp/Screen.swift
+++ b/happiNESsApp/Screen.swift
@@ -56,7 +56,7 @@ struct Screen: View {
 
     var body: some View {
         Image(self.image,
-              scale: 1/3.0,
+              scale: 1/Self.scale,
               orientation: .up,
               label: Text(verbatim: "Screen"))
         .interpolation(.none)


### PR DESCRIPTION
This PR accomplishes exactly what it says in the title, namely that the pixels in the screen are sharp now instead of blurred. Previously, this had to do with how `Canvas` was scaling up the image computed inside the closure passed in. Now we use a SwiftUI `Image` component instead, and call the `.interpolation()` modifier passing in `.none` to suppress blurring. It relies on a new computed property, `image`, which derives a `CGImage` from the screen buffer. 

It should be noted that the method of creating a new `CGImage` varies slightly from the one used in `Canvas` before, in that we create a `CFData` and create a `CGDataProvider` instance using it. Previously, it was ok to use unsafe code and rely on `bufferPointer` inside the closure of `Canvas` because we both created the image and immediately drew it to the graphics context. However, now we the creation of the image and the rendering of it are in two places, and so if we still used that unsafe code in the computed property, that pointer might have become invalid by the time we actually rendered it in the SwiftUI component. Instead, the computed property creates a `CFData` instance which _will have a brand new copy of the image data_ instead of indirectly relying on such a pointer.