### PR TITLE
CatAPUlting forward with an APU implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ For the time being, the unit tests are primarily focused on the implementations 
   <a href="https://www.nesdev.org/wiki/Emulator_tests">https://www.nesdev.org/wiki/Emulator_tests</a>
 - A page with the diassembled source code for Super Mario Bros.  
   <a href="https://6502disassembly.com/nes-smb/SuperMarioBros.html">https://6502disassembly.com/nes-smb/SuperMarioBros.html</a>
+- A Go implementation of an NES emulator  
+  <a href="https://github.com/fogleman/nes">https://github.com/fogleman/nes</a>
 - A page on Apple's Developer web site with an example project that you can download and experiment with to learn how to use part of the AVFAudio framework.  
   <a href="https://developer.apple.com/documentation/avfaudio/audio_engine/building_a_signal_generator">https://developer.apple.com/documentation/avfaudio/audio\_engine/building\_a\_signal\_generator</a>
 - GitHub repo with a ROM that comprehensively exercises the APU's sound capabilities.  

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ You can also specify the scale of the screen between 1x, 2x, and 3x through the 
 
 <img src="./images/set_scale.png" />
 
-It should be noted that at this time there is no sound emulation; hopefully, that will be coming soon!
-
 # Supported games
 
 So far, the following mappers and associated games have been tested in this emulator and are largely playable:
@@ -51,6 +49,8 @@ So far, the following mappers and associated games have been tested in this emul
 - 003
   - Gradius
   - Tiger Heli
+
+Also, this emulator now supports sound! Games should play and sound _pretty_ close to the original, however certain things like timings and IRQ interrupt handling may not be quite right and will need some work to correct.
 
 # Design
 
@@ -74,7 +74,7 @@ The strategy in the Rust version renders all background tiles and all sprites on
 
 There were also issues regarding properly handling sprites that were supposed to be appear to be rendered _behind_ the background tiles. In the Rust version, all sprites were rendered on top of the background tiles, but in the NES, each sprite has a so-called background priority bit that specifies whether it should effectively rendered on top of a background tile of behind it. Because all sprites were simply rendered regardless of this bit and _after_ the background was already rendered, certain aspects of the game looked odd, such as power-up mushrooms appeared in front of the block instead of looking like it emanted from within it, or at the end of world 1-1,  Mario looks like he stops in front of the pipe instead of actually entering it.
 
-In short, The NES actually renders graphics in the following way:
+This was all rewritten to be more congruent with the operation of an actual NES, namely that
 
 - For each visible scanline of the screen:
    - Determine which sprites intersect with the scanline and cache them
@@ -84,7 +84,7 @@ In short, The NES actually renders graphics in the following way:
        - If there is a first _background_ sprite with a non-transparent color, set the pixel's color accordingly
        - If we haven't found any of the above, set the pixel to the main background color
 
-And so, this emulator uses that strategy as a more faithful emulation. There are more fine-grained things that I have yet to properly emulate, such as true sprite zero hit detection, but this is a pretty good start.
+Sprite zero hit detection now happens _while evaluating pixels_ instead of waiting until just before rendering the screen buffer as the implemenation in the Rust tutorial does.
 
 ### Usage of enums instead of class hierarchies
 
@@ -136,3 +136,9 @@ For the time being, the unit tests are primarily focused on the implementations 
   <a href="https://nesdir.github.io/">https://nesdir.github.io/</a>
 - A page listing various test ROMS  
   <a href="https://www.nesdev.org/wiki/Emulator_tests">https://www.nesdev.org/wiki/Emulator_tests</a>
+- A page with the diassembled source code for Super Mario Bros.  
+  <a href="https://6502disassembly.com/nes-smb/SuperMarioBros.html">https://6502disassembly.com/nes-smb/SuperMarioBros.html</a>
+- A page on Apple's Developer web site with an example project that you can download and experiment with to learn how to use part of the AVFAudio framework.  
+  <a href="https://developer.apple.com/documentation/avfaudio/audio_engine/building_a_signal_generator">https://developer.apple.com/documentation/avfaudio/audio\_engine/building\_a\_signal\_generator</a>
+- GitHub repo with a ROM that comprehensively exercises the APU's sound capabilities.  
+  <a href="https://github.com/nesdoug/NES_SOUND">https://github.com/nesdoug/NES_SOUND</a>

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		8763D06A2C39B719006C1B4F /* RomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0692C39B719006C1B4F /* RomTests.swift */; };
 		8763D06C2C39E528006C1B4F /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06B2C39E528006C1B4F /* Screen.swift */; };
 		8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06D2C3A340C006C1B4F /* Tracing.swift */; };
+		8771BFA82CCD62C500306E13 /* Interrupt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8771BFA72CCD62C500306E13 /* Interrupt.swift */; };
 		877E970B2C7E4716007513B5 /* Joypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E970A2C7E4716007513B5 /* Joypad.swift */; };
 		878C69732CAA424400DA9BD4 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878C69722CAA424400DA9BD4 /* Address.swift */; };
 		878D81442C7FEE3B0076ED30 /* image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 878D81432C7FEE3B0076ED30 /* image.xcassets */; };
@@ -152,6 +153,7 @@
 		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
 		8763D06B2C39E528006C1B4F /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		8763D06D2C3A340C006C1B4F /* Tracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracing.swift; sourceTree = "<group>"; };
+		8771BFA72CCD62C500306E13 /* Interrupt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interrupt.swift; sourceTree = "<group>"; };
 		877E970A2C7E4716007513B5 /* Joypad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joypad.swift; sourceTree = "<group>"; };
 		878C69722CAA424400DA9BD4 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				870AABDF2CB37EA000E9F3B6 /* CPU+instructions.swift */,
 				870AABE12CB381C100E9F3B6 /* CPU+memory.swift */,
 				875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */,
+				8771BFA72CCD62C500306E13 /* Interrupt.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 				87D265162C9DECAF00C143B1 /* Mapper.swift */,
@@ -483,6 +486,7 @@
 				870AABE42CB382E000E9F3B6 /* CPU+execution.swift in Sources */,
 				87184D052C7028F10003D090 /* PPUStatusRegister.swift in Sources */,
 				870AABE02CB37EA000E9F3B6 /* CPU+instructions.swift in Sources */,
+				8771BFA82CCD62C500306E13 /* Interrupt.swift in Sources */,
 				87184D0E2C756BEB0003D090 /* OAMRegister.swift in Sources */,
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -43,6 +43,14 @@
 		8744B1912C1CC0C4001B44B5 /* CPU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1902C1CC0C4001B44B5 /* CPU.swift */; };
 		8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1922C1D6D59001B44B5 /* StatusRegister.swift */; };
 		874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51912CB9B51C00B12037 /* CachedSprite.swift */; };
+		874F51A92CBEEBA700B12037 /* APU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51A82CBEEBA700B12037 /* APU.swift */; };
+		874F51AB2CBF036600B12037 /* RegisterBit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51AA2CBF036600B12037 /* RegisterBit.swift */; };
+		874F51AD2CBF05BC00B12037 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51AC2CBF05BC00B12037 /* Register.swift */; };
+		874F51AF2CBF10DA00B12037 /* TriangleChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51AE2CBF10DA00B12037 /* TriangleChannel.swift */; };
+		874F51B12CC03F1500B12037 /* RegisterBitMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B02CC03F1500B12037 /* RegisterBitMask.swift */; };
+		874F51B32CC0638500B12037 /* Speaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B22CC0638500B12037 /* Speaker.swift */; };
+		874F51B52CC1D05D00B12037 /* PulseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B42CC1D05D00B12037 /* PulseChannel.swift */; };
+		874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B62CC1E7D800B12037 /* AudioRingBuffer.swift */; };
 		8763D0652C386A17006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0662C386A2E006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0682C39B61F006C1B4F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0672C39B61F006C1B4F /* Helpers.swift */; };
@@ -128,6 +136,14 @@
 		8744B1902C1CC0C4001B44B5 /* CPU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPU.swift; sourceTree = "<group>"; };
 		8744B1922C1D6D59001B44B5 /* StatusRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusRegister.swift; sourceTree = "<group>"; };
 		874F51912CB9B51C00B12037 /* CachedSprite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedSprite.swift; sourceTree = "<group>"; };
+		874F51A82CBEEBA700B12037 /* APU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APU.swift; sourceTree = "<group>"; };
+		874F51AA2CBF036600B12037 /* RegisterBit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBit.swift; sourceTree = "<group>"; };
+		874F51AC2CBF05BC00B12037 /* Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
+		874F51AE2CBF10DA00B12037 /* TriangleChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriangleChannel.swift; sourceTree = "<group>"; };
+		874F51B02CC03F1500B12037 /* RegisterBitMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBitMask.swift; sourceTree = "<group>"; };
+		874F51B22CC0638500B12037 /* Speaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speaker.swift; sourceTree = "<group>"; };
+		874F51B42CC1D05D00B12037 /* PulseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulseChannel.swift; sourceTree = "<group>"; };
+		874F51B62CC1E7D800B12037 /* AudioRingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRingBuffer.swift; sourceTree = "<group>"; };
 		8763D0642C386A17006C1B4F /* snake.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = snake.nes; sourceTree = "<group>"; };
 		8763D0672C39B61F006C1B4F /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
@@ -176,6 +192,7 @@
 				8719320A2C3366A900A73C22 /* Console.swift */,
 				871931F12C30BB2900A73C22 /* ContentView.swift */,
 				8763D06B2C39E528006C1B4F /* Screen.swift */,
+				874F51B22CC0638500B12037 /* Speaker.swift */,
 				871931F32C30BB2C00A73C22 /* Assets.xcassets */,
 				871931F82C30BB2C00A73C22 /* happiNESsApp.entitlements */,
 				871931F52C30BB2C00A73C22 /* Preview Content */,
@@ -229,6 +246,8 @@
 				8744B1762C1CB9B3001B44B5 /* happiNESs.docc */,
 				878C69722CAA424400DA9BD4 /* Address.swift */,
 				8744B18C2C1CB9F4001B44B5 /* AddressingMode.swift */,
+				874F51A82CBEEBA700B12037 /* APU.swift */,
+				874F51B62CC1E7D800B12037 /* AudioRingBuffer.swift */,
 				8719320F2C372F6900A73C22 /* Bus.swift */,
 				874F51912CB9B51C00B12037 /* CachedSprite.swift */,
 				871932132C3798B400A73C22 /* Cartridge.swift */,
@@ -252,8 +271,13 @@
 				870AABD92CB34E3000E9F3B6 /* PPU+tracing.swift */,
 				870AABDB2CB3533700E9F3B6 /* PPU+IO.swift */,
 				87184D042C7028F10003D090 /* PPUStatusRegister.swift */,
+				874F51B42CC1D05D00B12037 /* PulseChannel.swift */,
+				874F51AC2CBF05BC00B12037 /* Register.swift */,
+				874F51AA2CBF036600B12037 /* RegisterBit.swift */,
+				874F51B02CC03F1500B12037 /* RegisterBitMask.swift */,
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
 				8763D06D2C3A340C006C1B4F /* Tracing.swift */,
+				874F51AE2CBF10DA00B12037 /* TriangleChannel.swift */,
 				871F62332C6541D300132962 /* UInt16+bytes.swift */,
 				87D265142C9146F400C143B1 /* ViewPort.swift */,
 			);
@@ -420,6 +444,7 @@
 				8763D06C2C39E528006C1B4F /* Screen.swift in Sources */,
 				8719320C2C3366B000A73C22 /* Console.swift in Sources */,
 				878D81482C815E760076ED30 /* NESError.swift in Sources */,
+				874F51B32CC0638500B12037 /* Speaker.swift in Sources */,
 				871931F22C30BB2900A73C22 /* ContentView.swift in Sources */,
 				871931F02C30BB2900A73C22 /* happiNESsApp.swift in Sources */,
 			);
@@ -437,13 +462,16 @@
 				8744B1912C1CC0C4001B44B5 /* CPU.swift in Sources */,
 				871F62362C65631F00132962 /* ControllerRegister.swift in Sources */,
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
+				874F51A92CBEEBA700B12037 /* APU.swift in Sources */,
 				878C69732CAA424400DA9BD4 /* Address.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
 				874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */,
+				874F51AD2CBF05BC00B12037 /* Register.swift in Sources */,
 				87D265152C9146F400C143B1 /* ViewPort.swift in Sources */,
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,
+				874F51AB2CBF036600B12037 /* RegisterBit.swift in Sources */,
 				870AABE42CB382E000E9F3B6 /* CPU+execution.swift in Sources */,
 				87184D052C7028F10003D090 /* PPUStatusRegister.swift in Sources */,
 				870AABE02CB37EA000E9F3B6 /* CPU+instructions.swift in Sources */,
@@ -451,6 +479,7 @@
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
 				87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */,
+				874F51AF2CBF10DA00B12037 /* TriangleChannel.swift in Sources */,
 				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
 				87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
@@ -459,6 +488,9 @@
 				877E970B2C7E4716007513B5 /* Joypad.swift in Sources */,
 				870AABD82CB32FAA00E9F3B6 /* PPU+caching.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
+				874F51B12CC03F1500B12037 /* RegisterBitMask.swift in Sources */,
+				874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */,
+				874F51B52CC1D05D00B12037 /* PulseChannel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		878D81452C7FEE3B0076ED30 /* image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 878D81432C7FEE3B0076ED30 /* image.xcassets */; };
 		878D81472C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878D81482C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
+		878DCB8D2CCAB4CC00BE7ABB /* NoiseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */; };
 		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
 		87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* Mapper.swift */; };
 /* End PBXBuildFile section */
@@ -153,6 +154,7 @@
 		878C69722CAA424400DA9BD4 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
+		878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseChannel.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
 		87D265162C9DECAF00C143B1 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -263,6 +265,7 @@
 				871932112C37985700A73C22 /* Mirroring.swift */,
 				871932062C30E91D00A73C22 /* NESColor.swift */,
 				878D81462C815E760076ED30 /* NESError.swift */,
+				878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */,
 				87184D0D2C756BEB0003D090 /* OAMRegister.swift */,
 				8744B18E2C1CBB46001B44B5 /* Opcode.swift */,
 				871F622F2C62FE9E00132962 /* PPU.swift */,
@@ -460,6 +463,7 @@
 				870AABE22CB381C100E9F3B6 /* CPU+memory.swift in Sources */,
 				871F62302C62FE9E00132962 /* PPU.swift in Sources */,
 				8744B1912C1CC0C4001B44B5 /* CPU.swift in Sources */,
+				878DCB8D2CCAB4CC00BE7ABB /* NoiseChannel.swift in Sources */,
 				871F62362C65631F00132962 /* ControllerRegister.swift in Sources */,
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
 				874F51A92CBEEBA700B12037 /* APU.swift in Sources */,

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		874F51B32CC0638500B12037 /* Speaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B22CC0638500B12037 /* Speaker.swift */; };
 		874F51B52CC1D05D00B12037 /* PulseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B42CC1D05D00B12037 /* PulseChannel.swift */; };
 		874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F51B62CC1E7D800B12037 /* AudioRingBuffer.swift */; };
+		875F1ED12CCC7D0000DC8B7F /* DMCChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */; };
 		8763D0652C386A17006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0662C386A2E006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0682C39B61F006C1B4F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0672C39B61F006C1B4F /* Helpers.swift */; };
@@ -145,6 +146,7 @@
 		874F51B22CC0638500B12037 /* Speaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speaker.swift; sourceTree = "<group>"; };
 		874F51B42CC1D05D00B12037 /* PulseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulseChannel.swift; sourceTree = "<group>"; };
 		874F51B62CC1E7D800B12037 /* AudioRingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRingBuffer.swift; sourceTree = "<group>"; };
+		875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMCChannel.swift; sourceTree = "<group>"; };
 		8763D0642C386A17006C1B4F /* snake.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = snake.nes; sourceTree = "<group>"; };
 		8763D0672C39B61F006C1B4F /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				870AABE32CB382E000E9F3B6 /* CPU+execution.swift */,
 				870AABDF2CB37EA000E9F3B6 /* CPU+instructions.swift */,
 				870AABE12CB381C100E9F3B6 /* CPU+memory.swift */,
+				875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 				87D265162C9DECAF00C143B1 /* Mapper.swift */,
@@ -467,6 +470,7 @@
 				871F62362C65631F00132962 /* ControllerRegister.swift in Sources */,
 				871932072C30E91D00A73C22 /* NESColor.swift in Sources */,
 				874F51A92CBEEBA700B12037 /* APU.swift in Sources */,
+				875F1ED12CCC7D0000DC8B7F /* DMCChannel.swift in Sources */,
 				878C69732CAA424400DA9BD4 /* Address.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
 				874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */,

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -1,0 +1,182 @@
+//
+//  APU.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/15/24.
+//
+
+enum FramePeriod {
+    case four
+    case five
+}
+
+public struct APU {
+    static let frameCounterRate = CPU.frequency / 240.0
+
+    static let lengthTable: [UInt8] = [
+        10, 254, 20, 2, 40, 4, 80, 6, 160, 8, 60, 10, 14, 12, 26, 14,
+        12, 16, 24, 18, 48, 20, 96, 22, 192, 24, 72, 26, 16, 28, 32, 30,
+    ]
+
+    public var cycles: Int = 0
+    private var framePeriod: FramePeriod = .four
+    private var frameCounter: Int = 0
+    private var frameIrqInhibited: Bool = false
+    public var sampleRate: Double
+
+    // TODO: Add the other channels
+    public var triangle: TriangleChannel = TriangleChannel()
+    public var status: Register = 0x00
+    public var buffer = AudioRingBuffer()
+
+    public init(sampleRate: Double) {
+        self.sampleRate = sampleRate
+    }
+}
+
+extension APU {
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x4015:
+            self.status[.apuStatus]
+        default:
+            0x00
+        }
+    }
+
+    mutating public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x4008:
+            self.triangle.updateRegister1(byte: byte)
+        case 0x4009:
+            // Unused register
+            break
+        case 0x400A:
+            self.triangle.updateRegister3(byte: byte)
+        case 0x400B:
+            self.triangle.updateRegister4(byte: byte)
+        case 0x4015:
+            self.updateStatus(byte: byte)
+        case 0x4017:
+            self.updateFrameCounter(byte: byte)
+        default:
+            // For now, this is a no-op for any other addresses
+            break
+        }
+    }
+
+    mutating public func updateStatus(byte: UInt8) {
+        self.status = byte
+
+        // TODO: Handle the other channels when they are implemented
+        self.triangle.enabled = self.status[.triangleEnabled]
+
+        if !self.triangle.enabled {
+            self.triangle.lengthCounterValue = 0x00
+        }
+    }
+
+    mutating public func updateFrameCounter(byte: UInt8) {
+        self.framePeriod = byte[.frameSequencerMode] ? .five : .four
+        self.frameIrqInhibited = byte[.frameIrqInhibited]
+
+        if self.framePeriod == .five {
+            // TODO: Implement other steppers
+            self.stepEnvelope()
+            self.stepLength()
+        }
+    }
+}
+
+extension APU {
+    mutating public func tick(cpuCycles: Int) {
+        for _ in 0 ..< cpuCycles {
+            let cycleOld = self.cycles
+            self.cycles += 1
+            let cycleNew = self.cycles
+
+            self.stepTimer()
+
+            let frameOld = Int(Double(cycleOld) / Self.frameCounterRate)
+            let frameNew = Int(Double(cycleNew) / Self.frameCounterRate)
+            if frameOld != frameNew {
+                self.stepFrameCounter()
+            }
+
+            let sampleOld = Int(Double(cycleOld) / self.sampleRate)
+            let sampleNew = Int(Double(cycleNew) / self.sampleRate)
+            if sampleOld != sampleNew {
+//                print("Current cycle: \(self.cycles)")
+                self.sendSample()
+            }
+        }
+    }
+
+    mutating private func stepTimer() {
+        // TODO: call the methods on the other channels once they're implemented
+        self.triangle.stepTimer()
+    }
+
+    mutating private func stepFrameCounter() {
+        switch self.framePeriod {
+        case .four:
+            self.frameCounter = (self.frameCounter + 1) % 4
+
+            switch self.frameCounter {
+            case 0, 2:
+                self.stepEnvelope()
+            case 1:
+                self.stepEnvelope()
+                self.stepSweep()
+                self.stepLength()
+            case 3:
+                self.stepEnvelope()
+                self.stepSweep()
+                self.stepLength()
+                self.generateIRQ()
+            default:
+                fatalError("Encountered frame counter value of \(self.frameCounter) with frame period \(self.framePeriod)")
+            }
+        case .five:
+            self.frameCounter = (self.frameCounter + 1) % 5
+
+            switch self.frameCounter {
+            case 0, 2:
+                self.stepEnvelope()
+            case 1, 3:
+                self.stepEnvelope()
+                self.stepSweep()
+                self.stepLength()
+            default:
+                fatalError("Encountered frame counter value of \(self.frameCounter) with frame period \(self.framePeriod)")
+            }
+        }
+
+    }
+
+    mutating private func stepEnvelope() {
+        // TODO: call the methods on the other channels once they're implemented
+        self.triangle.stepCounter()
+    }
+
+    mutating private func stepSweep() {
+        // TODO: call the methods on the other channels once they're implemented
+    }
+
+    mutating private func stepLength() {
+        // TODO: call the methods on the other channels once they're implemented
+        self.triangle.stepLength()
+    }
+
+    mutating private func sendSample() {
+        // TODO: call the methods on the other channels once they're implemented
+        let sample = self.triangle.getSample()
+        if self.triangle.enabled {
+            print("Triangle sample: \(sample)")
+        }
+    }
+
+    mutating private func generateIRQ() {
+        // TODO!!!
+    }
+}

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -31,6 +31,7 @@ public struct APU {
     public var pulse2: PulseChannel = PulseChannel(channelNumber: .two)
     public var triangle: TriangleChannel = TriangleChannel()
     public var noise: NoiseChannel = NoiseChannel()
+    public var dmc: DMCChannel = DMCChannel()
     public var status: Register = 0x00
     public var buffer = AudioRingBuffer()
 
@@ -85,6 +86,14 @@ extension APU {
             self.noise.updateRegister3(byte: byte)
         case 0x400F:
             self.noise.updateRegister4(byte: byte)
+        case 0x4010:
+            self.dmc.updateRegister1(byte: byte)
+        case 0x4011:
+            self.dmc.updateRegister2(byte: byte)
+        case 0x4012:
+            self.dmc.updateRegister3(byte: byte)
+        case 0x4013:
+            self.dmc.updateRegister4(byte: byte)
         case 0x4015:
             self.updateStatus(byte: byte)
         case 0x4017:

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -27,8 +27,8 @@ public struct APU {
     public var sampleRate: Double
 
     // TODO: Add the other channels
-    public var pulse1: PulseChannel = PulseChannel(channel: .one)
-    public var pulse2: PulseChannel = PulseChannel(channel: .two)
+    public var pulse1: PulseChannel = PulseChannel(channelNumber: .one)
+    public var pulse2: PulseChannel = PulseChannel(channelNumber: .two)
     public var triangle: TriangleChannel = TriangleChannel()
     public var noise: NoiseChannel = NoiseChannel()
     public var status: Register = 0x00

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -146,6 +146,8 @@ extension APU {
                 self.stepEnvelope()
                 self.stepSweep()
                 self.stepLength()
+            case 4:
+                break
             default:
                 fatalError("Encountered frame counter value of \(self.frameCounter) with frame period \(self.framePeriod)")
             }
@@ -171,9 +173,7 @@ extension APU {
         // TODO: call the methods on the other channels once they're implemented
         let triangleSample = self.triangle.getSample()
         let signal = mix(pulse1: 0, pulse2: 0, triangle: triangleSample, noise: 0, dmc: 0)
-        if self.triangle.enabled {
-            print("Triangle signal: \(signal)")
-        }
+        self.buffer.append(value: signal)
     }
 
     private func mixPulses(pulse1: UInt8, pulse2: UInt8) -> Float {

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -21,6 +21,7 @@ public struct APU {
         12, 16, 24, 18, 48, 20, 96, 22, 192, 24, 72, 26, 16, 28, 32, 30,
     ]
 
+    public var bus: Bus? = nil
     public var cycles: Int = 0
     private var sequencerMode: SequencerMode = .four
     private var frameIrqInhibited: Bool = false
@@ -107,7 +108,6 @@ extension APU {
     mutating public func updateStatus(byte: UInt8) {
         self.status = byte
 
-        // TODO: Handle the other channels when they are implemented
         self.pulse1.enabled = self.status[.pulse1Enabled]
         self.pulse2.enabled = self.status[.pulse2Enabled]
         self.triangle.enabled = self.status[.triangleEnabled]
@@ -140,7 +140,6 @@ extension APU {
         self.frameIrqInhibited = byte[.frameIrqInhibited]
 
         if self.sequencerMode == .five {
-            // TODO: Implement other steppers
             self.stepEnvelope()
             self.stepSweep()
             self.stepLength()
@@ -176,7 +175,6 @@ extension APU {
         //     second CPU cycle and thus produce only even periods."
 
         if self.cycles % 2 == 0 {
-            // TODO: call the methods on the other channels once they're implemented
             self.pulse1.stepTimer()
             self.pulse2.stepTimer()
             self.noise.stepTimer()
@@ -297,6 +295,6 @@ extension APU {
     }
 
     mutating private func generateIRQ() {
-        // TODO!!!
+        self.bus!.triggerIrq()
     }
 }

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -106,7 +106,6 @@ extension APU {
             let sampleOld = Int(Double(cycleOld) / self.sampleRate)
             let sampleNew = Int(Double(cycleNew) / self.sampleRate)
             if sampleOld != sampleNew {
-//                print("Current cycle: \(self.cycles)")
                 self.sendSample()
             }
         }
@@ -170,10 +169,27 @@ extension APU {
 
     mutating private func sendSample() {
         // TODO: call the methods on the other channels once they're implemented
-        let sample = self.triangle.getSample()
+        let triangleSample = self.triangle.getSample()
+        let signal = mix(pulse1: 0, pulse2: 0, triangle: triangleSample, noise: 0, dmc: 0)
         if self.triangle.enabled {
-            print("Triangle sample: \(sample)")
+            print("Triangle signal: \(signal)")
         }
+    }
+
+    private func mixPulses(pulse1: UInt8, pulse2: UInt8) -> Float {
+        let denominator = (8128.0 / (Float(pulse1) + Float(pulse2))) + 100.0
+        return 95.88 /  denominator
+    }
+
+    private func mixTnd(triangle: UInt8, noise: UInt8, dmc: UInt8) -> Float {
+        let denominator = (Float(triangle) / 8227.0) + (Float(noise) / 12241.0) + (Float(dmc) / 22638.0)
+        return 159.79 / ((1 / denominator) + 100.0)
+    }
+
+    private func mix(pulse1: UInt8, pulse2: UInt8, triangle: UInt8, noise: UInt8, dmc: UInt8) -> Float {
+        let pulses = mixPulses(pulse1: pulse1, pulse2: pulse2)
+        let tnd = mixTnd(triangle: triangle, noise: noise, dmc: dmc)
+        return pulses + tnd
     }
 
     mutating private func generateIRQ() {

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -112,6 +112,7 @@ extension APU {
         self.pulse2.enabled = self.status[.pulse2Enabled]
         self.triangle.enabled = self.status[.triangleEnabled]
         self.noise.enabled = self.status[.noiseEnabled]
+        self.dmc.enabled = self.status[.dmcEnabled]
 
         if !self.pulse1.enabled {
             self.pulse1.lengthCounterValue = 0x00
@@ -124,6 +125,13 @@ extension APU {
         }
         if !self.noise.enabled {
             self.noise.lengthCounterValue = 0x00
+        }
+        if !self.dmc.enabled {
+            self.dmc.currentLength = 0
+        } else {
+            if self.dmc.currentLength == 0 {
+                self.dmc.restart()
+            }
         }
     }
 
@@ -172,6 +180,7 @@ extension APU {
             self.pulse1.stepTimer()
             self.pulse2.stepTimer()
             self.noise.stepTimer()
+            self.dmc.stepTimer()
         }
 
         self.triangle.stepTimer()
@@ -258,11 +267,13 @@ extension APU {
         let pulse2Sample = self.pulse2.getSample()
         let triangleSample = self.triangle.getSample()
         let noiseSample = self.noise.getSample()
+        let dmcSample = self.dmc.getSample()
+
         let signal = mix(pulse1: pulse1Sample,
                          pulse2: pulse2Sample,
                          triangle: triangleSample,
                          noise: noiseSample,
-                         dmc: 0)
+                         dmc: dmcSample)
         self.buffer.append(value: signal)
     }
 

--- a/happiNESs/AudioRingBuffer.swift
+++ b/happiNESs/AudioRingBuffer.swift
@@ -1,0 +1,32 @@
+//
+//  AudioRingBuffer.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/17/24.
+//
+
+import Foundation
+
+public class AudioRingBuffer {
+    private var buffer: [Float] = [Float](repeating: 0.0, count: 44100)
+    private var takeIndex: Int = 0
+    private var appendIndex: Int = 0
+}
+
+extension AudioRingBuffer {
+    public func take() -> Float? {
+        if self.takeIndex < self.appendIndex {
+            let currentValue = self.buffer[takeIndex % self.buffer.count]
+            takeIndex += 1
+            return currentValue
+        }
+
+        return nil
+    }
+
+    public func append(value: Float) {
+        precondition(appendIndex >= takeIndex)
+        self.buffer[appendIndex % self.buffer.count] = value
+        appendIndex += 1
+    }
+}

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -11,13 +11,13 @@ public class Bus {
     static let ppuRegistersMirrorsBegin: UInt16 = 0x2000;
     static let ppuRegistersMirrorsEnd: UInt16 = 0x3FFF;
 
+    public var cpu: CPU? = nil
     public var ppu: PPU
     public var apu: APU
     var cartridge: Cartridge?
     var vram: [UInt8]
     var cycles: Int
     var joypad: Joypad
-    public var interrupt: Interrupt = .none
 
     public init() {
         self.ppu = PPU()
@@ -33,6 +33,7 @@ public class Bus {
         // the PPU and APU.
         self.ppu.bus = self
         self.apu.dmc.bus = self
+        self.apu.bus = self
     }
 
     public func loadCartridge(cartridge: Cartridge) {
@@ -134,7 +135,6 @@ extension Bus {
         case 0x8000 ... 0xFFFF:
             self.cartridge!.writeByte(address: address, byte: byte)
         default:
-            // TODO: Implement memory writing to these addresses?
             break
         }
     }
@@ -146,5 +146,15 @@ extension Bus {
 
         self.apu.tick(cpuCycles: cycles)
         return self.ppu.tick(cpuCycles: cycles)
+    }
+
+    public func triggerNmi() {
+        self.cpu!.interrupt = .nmi
+    }
+
+    public func triggerIrq() {
+        if !self.cpu!.statusRegister[.interruptsDisabled] {
+            self.cpu!.interrupt = .irq
+        }
     }
 }

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -17,6 +17,7 @@ public class Bus {
     var vram: [UInt8]
     var cycles: Int
     var joypad: Joypad
+    public var interrupt: Interrupt = .none
 
     public init() {
         self.ppu = PPU()
@@ -28,7 +29,9 @@ public class Bus {
         self.joypad = Joypad()
 
         // NOTA BENE: We need to do this because there needs to be
-        // bidirectional communication between the bus and the APU.
+        // bidirectional communication between the bus and both
+        // the PPU and APU.
+        self.ppu.bus = self
         self.apu.dmc.bus = self
     }
 
@@ -143,9 +146,5 @@ extension Bus {
 
         self.apu.tick(cpuCycles: cycles)
         return self.ppu.tick(cpuCycles: cycles)
-    }
-
-    func pollNmiStatus() -> UInt8? {
-        return self.ppu.pollNmiInterrupt()
     }
 }

--- a/happiNESs/CPU+execution.swift
+++ b/happiNESs/CPU+execution.swift
@@ -34,8 +34,12 @@ extension CPU {
     // This method returns the value from the call to Bus.tick()
     // which represents whether or not the screen needs to be redrawn
     mutating func executeInstruction() -> Bool {
-        if let _ = self.bus.pollNmiStatus() {
+        switch self.bus.interrupt {
+        case .nmi:
             self.handleNmiInterrupt()
+            self.bus.interrupt = .none
+        default:
+            break
         }
 
         if self.tracingOn {

--- a/happiNESs/CPU+execution.swift
+++ b/happiNESs/CPU+execution.swift
@@ -12,11 +12,11 @@ public enum StopCondition {
 
 extension CPU {
     // NOTA BENE: This method is only ever called from unit tests.
-    mutating public func executeInstructions(stoppingAfter: Int) {
+    public func executeInstructions(stoppingAfter: Int) {
         executeInstructions(stoppingAfter: .instructions(stoppingAfter))
     }
 
-    mutating public func executeInstructions(stoppingAfter: StopCondition) {
+    public func executeInstructions(stoppingAfter: StopCondition) {
         switch stoppingAfter {
         case .instructions(let count):
             (0..<count).forEach { i in
@@ -33,11 +33,14 @@ extension CPU {
 
     // This method returns the value from the call to Bus.tick()
     // which represents whether or not the screen needs to be redrawn
-    mutating func executeInstruction() -> Bool {
-        switch self.bus.interrupt {
+    func executeInstruction() -> Bool {
+        switch self.interrupt {
         case .nmi:
-            self.handleNmiInterrupt()
-            self.bus.interrupt = .none
+            self.handleNmi()
+            self.interrupt = .none
+        case .irq:
+            self.handleIrq()
+            self.interrupt = .none
         default:
             break
         }

--- a/happiNESs/CPU+instructions.swift
+++ b/happiNESs/CPU+instructions.swift
@@ -6,7 +6,7 @@
 //
 
 extension CPU {
-    mutating func adc(addressingMode: AddressingMode) -> (Bool, Int) {
+    func adc(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         let carry: UInt8 = self.statusRegister[.carry] ? 0x01 : 0x00
@@ -20,7 +20,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func and(addressingMode: AddressingMode) -> (Bool, Int) {
+    func and(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         self.accumulator &= value
@@ -29,7 +29,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func asl(addressingMode: AddressingMode) -> (Bool, Int) {
+    func asl(addressingMode: AddressingMode) -> (Bool, Int) {
         if addressingMode == .accumulator {
             self.statusRegister[.carry] = self.accumulator >> 7 == 1
             self.accumulator <<= 1
@@ -46,19 +46,19 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func bcc() -> (Bool, Int) {
+    func bcc() -> (Bool, Int) {
         return self.branch(condition: !self.statusRegister[.carry])
     }
 
-    mutating func bcs() -> (Bool, Int) {
+    func bcs() -> (Bool, Int) {
         return self.branch(condition: self.statusRegister[.carry])
     }
 
-    mutating func beq() -> (Bool, Int) {
+    func beq() -> (Bool, Int) {
         return self.branch(condition: self.statusRegister[.zero])
     }
 
-    mutating private func branch(condition: Bool) -> (Bool, Int) {
+    private func branch(condition: Bool) -> (Bool, Int) {
         if condition {
             let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: .relative)
             self.programCounter = address
@@ -69,7 +69,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func bit(addressingMode: AddressingMode) -> (Bool, Int) {
+    func bit(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode);
         let value = self.readByte(address: address);
         let result = self.accumulator & value;
@@ -80,19 +80,19 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func bmi() -> (Bool, Int) {
+    func bmi() -> (Bool, Int) {
         return self.branch(condition: self.statusRegister[.negative])
     }
 
-    mutating func bne() -> (Bool, Int) {
+    func bne() -> (Bool, Int) {
         return self.branch(condition: !self.statusRegister[.zero])
     }
 
-    mutating func bpl() -> (Bool, Int) {
+    func bpl() -> (Bool, Int) {
         return self.branch(condition: !self.statusRegister[.negative])
     }
 
-    mutating func brk() -> (Bool, Int) {
+    func brk() -> (Bool, Int) {
         let currentStatus = self.statusRegister.rawValue
         // NOTA BENE: We've already advanced the program counter upon consuming the
         // `BRK` byte; now we need to advance it one more time since the byte after
@@ -103,48 +103,48 @@ extension CPU {
         self.pushStack(word: self.programCounter)
         self.pushStack(byte: currentStatus)
         self.programCounter = self.readWord(address: Self.interruptVectorAddress)
-        self.statusRegister[.interrupt] = true
+        self.statusRegister[.interruptsDisabled] = true
 
         return (true, 0)
     }
 
-    mutating func bvc() -> (Bool, Int) {
+    func bvc() -> (Bool, Int) {
         return self.branch(condition: !self.statusRegister[.overflow])
     }
 
-    mutating func bvs() -> (Bool, Int) {
+    func bvs() -> (Bool, Int) {
         return self.branch(condition: self.statusRegister[.overflow])
     }
 
-    mutating private func clearBit(bit: StatusRegister.Element) {
+    func clearBit(bit: StatusRegister.Element) {
         self.statusRegister[bit] = false
     }
 
-    mutating func clc() -> (Bool, Int) {
+    func clc() -> (Bool, Int) {
         self.clearBit(bit: .carry)
 
         return (false, 0)
     }
 
-    mutating func cld() -> (Bool, Int) {
+    func cld() -> (Bool, Int) {
         self.clearBit(bit: .decimalMode)
 
         return (false, 0)
     }
 
-    mutating func cli() -> (Bool, Int) {
-        self.clearBit(bit: .interrupt)
+    func cli() -> (Bool, Int) {
+        self.clearBit(bit: .interruptsDisabled)
 
         return (false, 0)
     }
 
-    mutating func clv() -> (Bool, Int) {
+    func clv() -> (Bool, Int) {
         self.clearBit(bit: .overflow)
 
         return (false, 0)
     }
 
-    mutating private func compareMemory(addressingMode: AddressingMode, to registerValue: UInt8) -> Bool {
+    private func compareMemory(addressingMode: AddressingMode, to registerValue: UInt8) -> Bool {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let memoryValue = self.readByte(address: address)
 
@@ -154,25 +154,25 @@ extension CPU {
         return pageCrossed
     }
 
-    mutating func cmp(addressingMode: AddressingMode) -> (Bool, Int) {
+    func cmp(addressingMode: AddressingMode) -> (Bool, Int) {
         let pageCrossed = self.compareMemory(addressingMode: addressingMode, to: self.accumulator)
 
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func cpx(addressingMode: AddressingMode) -> (Bool, Int) {
+    func cpx(addressingMode: AddressingMode) -> (Bool, Int) {
         let _ = self.compareMemory(addressingMode: addressingMode, to: self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func cpy(addressingMode: AddressingMode) -> (Bool, Int) {
+    func cpy(addressingMode: AddressingMode) -> (Bool, Int) {
         let _ = self.compareMemory(addressingMode: addressingMode, to: self.yRegister)
 
         return (false, 0)
     }
 
-    mutating func dcp(addressingMode: AddressingMode) -> (Bool, Int) {
+    func dcp(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
 
@@ -184,7 +184,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func dec(addressingMode: AddressingMode) -> (Bool, Int) {
+    func dec(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         self.writeByte(address: address, byte: value &- 1)
@@ -193,14 +193,14 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func dex() -> (Bool, Int) {
+    func dex() -> (Bool, Int) {
         self.xRegister = self.xRegister &- 1
         self.updateZeroAndNegativeFlags(result: self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func dey() -> (Bool, Int) {
+    func dey() -> (Bool, Int) {
         self.yRegister = self.yRegister &- 1
         self.updateZeroAndNegativeFlags(result: self.yRegister)
 
@@ -208,7 +208,7 @@ extension CPU {
     }
 
 
-    mutating func eor(addressingMode: AddressingMode) -> (Bool, Int) {
+    func eor(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode);
         let value = self.readByte(address: address);
         self.accumulator ^= value;
@@ -217,7 +217,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func inc(addressingMode: AddressingMode) -> (Bool, Int) {
+    func inc(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         self.writeByte(address: address, byte: value &+ 1)
@@ -226,21 +226,21 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func inx() -> (Bool, Int) {
+    func inx() -> (Bool, Int) {
         self.xRegister = self.xRegister &+ 1
         self.updateZeroAndNegativeFlags(result: self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func iny() -> (Bool, Int) {
+    func iny() -> (Bool, Int) {
         self.yRegister = self.yRegister &+ 1
         self.updateZeroAndNegativeFlags(result: self.yRegister)
 
         return (false, 0)
     }
 
-    mutating func isb(addressingMode: AddressingMode) -> (Bool, Int) {
+    func isb(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         self.writeByte(address: address, byte: self.readByte(address: address) &+ 1)
 
@@ -249,14 +249,14 @@ extension CPU {
         return (programCounterMutated, 0)
     }
 
-    mutating func jmp(addressingMode: AddressingMode) -> (Bool, Int) {
+    func jmp(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         self.programCounter = address
 
         return (true, 0)
     }
 
-    mutating func jsr() -> (Bool, Int) {
+    func jsr() -> (Bool, Int) {
         let (subroutineAddress, _) = self.getAbsoluteAddress(addressingMode: .absolute);
         // ACHTUNG!!! Note that this is pointing to the last byte of the `JSR` instruction!
         let returnAddress = self.programCounter + 2 - 1
@@ -266,7 +266,7 @@ extension CPU {
         return (true, 0)
     }
 
-    mutating func lax(addressingMode: AddressingMode) -> (Bool, Int) {
+    func lax(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address);
 
@@ -277,7 +277,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func lda(addressingMode: AddressingMode) -> (Bool, Int) {
+    func lda(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address);
         self.accumulator = value;
@@ -286,7 +286,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func ldx(addressingMode: AddressingMode) -> (Bool, Int) {
+    func ldx(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address);
         self.xRegister = value;
@@ -295,7 +295,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func ldy(addressingMode: AddressingMode) -> (Bool, Int) {
+    func ldy(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address);
         self.yRegister = value;
@@ -304,7 +304,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func lsr(addressingMode: AddressingMode) -> (Bool, Int) {
+    func lsr(addressingMode: AddressingMode) -> (Bool, Int) {
         if addressingMode == .accumulator {
             self.statusRegister[.carry] = self.accumulator & 0b0000_0001 == 1
             self.accumulator >>= 1
@@ -321,7 +321,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func nop(addressingMode: AddressingMode) -> (Bool, Int) {
+    func nop(addressingMode: AddressingMode) -> (Bool, Int) {
         if addressingMode == .implicit {
             return (false, 0)
         }
@@ -330,7 +330,7 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating func ora(addressingMode: AddressingMode) -> (Bool, Int) {
+    func ora(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address);
         self.accumulator |= value;
@@ -339,29 +339,29 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating public func pushStack(byte: UInt8) {
+    public func pushStack(byte: UInt8) {
         self.writeByte(address: Self.stackBottomMemoryAddress + UInt16(self.stackPointer), byte: byte)
         self.stackPointer = self.stackPointer &- 1
     }
 
-    mutating public func pushStack(word: UInt16) {
+    public func pushStack(word: UInt16) {
         self.pushStack(byte: word.highByte)
         self.pushStack(byte: word.lowByte)
     }
 
-    mutating private func popStack() -> UInt8 {
+    private func popStack() -> UInt8 {
         self.stackPointer = self.stackPointer &+ 1
         let byte = self.readByte(address: Self.stackBottomMemoryAddress + UInt16(self.stackPointer))
         return byte
     }
 
-    mutating func pha() -> (Bool, Int) {
+    func pha() -> (Bool, Int) {
         self.pushStack(byte: self.accumulator)
 
         return (false, 0)
     }
 
-    mutating func php() -> (Bool, Int) {
+    func php() -> (Bool, Int) {
         // NOTA BENE: We need to set the so-called B flag upon a push to the stack:
         //
         //    https://www.nesdev.org/wiki/Status_flags#The_B_flag
@@ -370,14 +370,14 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func pla() -> (Bool, Int) {
+    func pla() -> (Bool, Int) {
         self.accumulator = self.popStack()
         self.updateZeroAndNegativeFlags(result: self.accumulator)
 
         return (false, 0)
     }
 
-    mutating func plp() -> (Bool, Int) {
+    func plp() -> (Bool, Int) {
         self.statusRegister.rawValue = self.popStack()
         self.statusRegister[.break] = false
         self.statusRegister[.unused] = true
@@ -385,7 +385,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func rla(addressingMode: AddressingMode) -> (Bool, Int) {
+    func rla(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
@@ -397,7 +397,7 @@ extension CPU {
         return (programCounterMutated, 0)
     }
 
-    mutating func rol(addressingMode: AddressingMode) -> (Bool, Int) {
+    func rol(addressingMode: AddressingMode) -> (Bool, Int) {
         let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
 
         if addressingMode == .accumulator {
@@ -419,7 +419,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func ror(addressingMode: AddressingMode) -> (Bool, Int) {
+    func ror(addressingMode: AddressingMode) -> (Bool, Int) {
         let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
 
         if addressingMode == .accumulator {
@@ -444,7 +444,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func rra(addressingMode: AddressingMode) -> (Bool, Int) {
+    func rra(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         let oldCarry: UInt8 = self.statusRegister[.carry] ? 1 : 0
@@ -456,7 +456,7 @@ extension CPU {
         return (programCounterMutated, 0)
     }
 
-    mutating func rti() -> (Bool, Int) {
+    func rti() -> (Bool, Int) {
         self.statusRegister.rawValue = self.popStack()
         self.statusRegister[.break] = false
         self.statusRegister[.unused] = true
@@ -469,7 +469,7 @@ extension CPU {
         return (true, 0)
     }
 
-    mutating func rts() -> (Bool, Int) {
+    func rts() -> (Bool, Int) {
         let addressLow = self.popStack()
         let addressHigh = self.popStack()
         // ACHTUNG!!! Note that this only works in conjunction with the `JSR` instruction!
@@ -479,14 +479,14 @@ extension CPU {
         return (true, 0)
     }
 
-    mutating func sax(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sax(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         self.writeByte(address: address, byte: self.accumulator & self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func sbc(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sbc(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, pageCrossed) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         let carry: UInt8 = self.statusRegister[.carry] ? 0x01 : 0x00
@@ -500,29 +500,29 @@ extension CPU {
         return (false, pageCrossed ? 1 : 0)
     }
 
-    mutating private func setBit(bit: StatusRegister.Element) {
+    private func setBit(bit: StatusRegister.Element) {
         self.statusRegister[bit] = true
     }
 
-    mutating func sec() -> (Bool, Int) {
+    func sec() -> (Bool, Int) {
         self.setBit(bit: .carry)
 
         return (false, 0)
     }
 
-    mutating func sed() -> (Bool, Int) {
+    func sed() -> (Bool, Int) {
         self.setBit(bit: .decimalMode)
 
         return (false, 0)
     }
 
-    mutating func sei() -> (Bool, Int) {
-        self.setBit(bit: .interrupt)
+    func sei() -> (Bool, Int) {
+        self.setBit(bit: .interruptsDisabled)
 
         return (false, 0)
     }
 
-    mutating func sha(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sha(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let result = self.accumulator & self.xRegister & address.highByte
         self.writeByte(address: address, byte: result)
@@ -530,7 +530,7 @@ extension CPU {
         return (false, 0)
     }
 
-    mutating func slo(addressingMode: AddressingMode) -> (Bool, Int) {
+    func slo(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let oldValue = self.readByte(address: address)
         self.writeByte(address: address, byte: oldValue << 1)
@@ -541,7 +541,7 @@ extension CPU {
         return (programCounterMutated, 0)
     }
 
-    mutating func sre(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sre(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         let value = self.readByte(address: address)
         self.writeByte(address: address, byte: value >> 1)
@@ -552,69 +552,69 @@ extension CPU {
         return (programCounterMutated, 0)
     }
 
-    mutating func sta(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sta(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode)
         self.writeByte(address: address, byte: self.accumulator)
 
         return (false, 0)
     }
 
-    mutating func stx(addressingMode: AddressingMode) -> (Bool, Int) {
+    func stx(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode);
         self.writeByte(address: address, byte: self.xRegister);
 
         return (false, 0)
     }
 
-    mutating func sty(addressingMode: AddressingMode) -> (Bool, Int) {
+    func sty(addressingMode: AddressingMode) -> (Bool, Int) {
         let (address, _) = self.getAbsoluteAddress(addressingMode: addressingMode);
         self.writeByte(address: address, byte: self.yRegister);
 
         return (false, 0)
     }
 
-    mutating func tax() -> (Bool, Int) {
+    func tax() -> (Bool, Int) {
         self.xRegister = self.accumulator;
         self.updateZeroAndNegativeFlags(result: self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func tay() -> (Bool, Int) {
+    func tay() -> (Bool, Int) {
         self.yRegister = self.accumulator;
         self.updateZeroAndNegativeFlags(result: self.yRegister)
 
         return (false, 0)
     }
 
-    mutating func tsx() -> (Bool, Int) {
+    func tsx() -> (Bool, Int) {
         self.xRegister = self.stackPointer;
         self.updateZeroAndNegativeFlags(result: self.xRegister)
 
         return (false, 0)
     }
 
-    mutating func txa() -> (Bool, Int) {
+    func txa() -> (Bool, Int) {
         self.accumulator = self.xRegister;
         self.updateZeroAndNegativeFlags(result: self.accumulator)
 
         return (false, 0)
     }
 
-    mutating func txs() -> (Bool, Int) {
+    func txs() -> (Bool, Int) {
         self.stackPointer = self.xRegister;
 
         return (false, 0)
     }
 
-    mutating func tya() -> (Bool, Int) {
+    func tya() -> (Bool, Int) {
         self.accumulator = self.yRegister;
         self.updateZeroAndNegativeFlags(result: self.accumulator)
 
         return (false, 0)
     }
 
-    mutating private func updateZeroAndNegativeFlags(result: UInt8) {
+    private func updateZeroAndNegativeFlags(result: UInt8) {
         self.statusRegister[.zero] = result == 0
         self.statusRegister[.negative] = (result & 0b1000_0000) != 0
     }

--- a/happiNESs/CPU+memory.swift
+++ b/happiNESs/CPU+memory.swift
@@ -10,7 +10,7 @@ extension CPU {
         return (fromAddress & 0xFF00) != (toAddress & 0xFF00)
     }
 
-    mutating func getAbsoluteAddress(addressingMode: AddressingMode) -> (UInt16, Bool) {
+    func getAbsoluteAddress(addressingMode: AddressingMode) -> (UInt16, Bool) {
         let address = self.programCounter
 
         switch addressingMode {
@@ -139,13 +139,13 @@ extension CPU {
         }
     }
 
-    mutating func readWord(address: UInt16) -> UInt16 {
+    func readWord(address: UInt16) -> UInt16 {
         let lowByte = self.readByte(address: address)
         let highByte = self.readByte(address: address + 1)
         return UInt16(lowByte: lowByte, highByte: highByte)
     }
 
-    mutating func readByte(address: UInt16) -> UInt8 {
+    func readByte(address: UInt16) -> UInt8 {
         self.bus.readByte(address: address)
     }
 
@@ -161,11 +161,11 @@ extension CPU {
         return UInt16(lowByte: lowByte, highByte: highByte)
     }
 
-    mutating public func writeByte(address: UInt16, byte: UInt8) {
+    public func writeByte(address: UInt16, byte: UInt8) {
         self.bus.writeByte(address: address, byte: byte)
     }
 
-    mutating func writeWord(address: UInt16, word: UInt16) {
+    func writeWord(address: UInt16, word: UInt16) {
         self.writeByte(address: address, byte: word.lowByte);
         self.writeByte(address: address + 1, byte: word.highByte);
     }

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -6,6 +6,8 @@
 //
 
 public struct CPU {
+    static let frequency = 1789773.0
+
     static let nmiVectorAddress: UInt16 = 0xFFFA
     static let resetVectorAddress: UInt16 = 0xFFFC
     static let interruptVectorAddress: UInt16 = 0xFFFE

--- a/happiNESs/DMCChannel.swift
+++ b/happiNESs/DMCChannel.swift
@@ -10,7 +10,7 @@ public struct DMCChannel {
         214, 190, 170, 160, 143, 127, 113, 107, 95, 80, 71, 64, 53, 42, 36, 27,
     ]
 
-    public var cpu: CPU? = nil
+    public var bus: Bus? = nil
     public var enabled: Bool = false
 
     private var irqEnabled: Bool = false
@@ -75,8 +75,7 @@ extension DMCChannel {
             // TODO: Figure out how best to do this
             // self.cpu.stall += 4
 
-            // TODO: Figure out how to pass in reference to CPU
-            self.shiftRegister = self.cpu!.readByteWithoutMutating(address: self.currentAddress)
+            self.shiftRegister = self.bus!.readByte(address: self.currentAddress)
             self.bitCount = 8
             self.currentAddress += 1
             if self.currentAddress == 0 {

--- a/happiNESs/DMCChannel.swift
+++ b/happiNESs/DMCChannel.swift
@@ -10,6 +10,7 @@ public struct DMCChannel {
         214, 190, 170, 160, 143, 127, 113, 107, 95, 80, 71, 64, 53, 42, 36, 27,
     ]
 
+    public var cpu: CPU? = nil
     public var enabled: Bool = false
 
     private var irqEnabled: Bool = false
@@ -21,7 +22,7 @@ public struct DMCChannel {
     private var sampleAddress: UInt16 = 0x0000
     private var currentAddress: UInt16 = 0x0000
     private var sampleLength: UInt16 = 0x0000
-    private var currentLength: UInt16 = 0x0000
+    public var currentLength: UInt16 = 0x0000
 
     private var shiftRegister: UInt8 = 0x00
     private var bitCount: Int = 0
@@ -49,7 +50,7 @@ extension DMCChannel {
 }
 
 extension DMCChannel {
-    mutating private func stepTimer() {
+    mutating public func stepTimer() {
         if !self.enabled {
             return
         }
@@ -64,7 +65,7 @@ extension DMCChannel {
         }
     }
 
-    mutating private func restart() {
+    mutating public func restart() {
         self.currentAddress = self.sampleAddress
         self.currentLength = self.sampleLength
     }
@@ -75,7 +76,7 @@ extension DMCChannel {
             // self.cpu.stall += 4
 
             // TODO: Figure out how to pass in reference to CPU
-            // self.shiftRegister = self.cpu.Read(self.currentAddress)
+            self.shiftRegister = self.cpu!.readByteWithoutMutating(address: self.currentAddress)
             self.bitCount = 8
             self.currentAddress += 1
             if self.currentAddress == 0 {
@@ -108,7 +109,7 @@ extension DMCChannel {
         self.bitCount -= 1
     }
 
-    private func getSample() -> UInt8 {
+    public func getSample() -> UInt8 {
         return self.sampleValue
     }
 }

--- a/happiNESs/DMCChannel.swift
+++ b/happiNESs/DMCChannel.swift
@@ -1,0 +1,8 @@
+//
+//  DMCChannel.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/25/24.
+//
+
+import Foundation

--- a/happiNESs/DMCChannel.swift
+++ b/happiNESs/DMCChannel.swift
@@ -5,4 +5,110 @@
 //  Created by Danielle Kefford on 10/25/24.
 //
 
-import Foundation
+public struct DMCChannel {
+    static let periodTable: [UInt8] = [
+        214, 190, 170, 160, 143, 127, 113, 107, 95, 80, 71, 64, 53, 42, 36, 27,
+    ]
+
+    public var enabled: Bool = false
+
+    private var irqEnabled: Bool = false
+    private var loopEnabled: Bool = false
+    private var loopPeriod: UInt8 = 0x00
+    private var loopValue: UInt8 = 0x00
+
+    private var loadCounter: UInt8 = 0x00
+    private var sampleAddress: UInt16 = 0x0000
+    private var currentAddress: UInt16 = 0x0000
+    private var sampleLength: UInt16 = 0x0000
+    private var currentLength: UInt16 = 0x0000
+
+    private var shiftRegister: UInt8 = 0x00
+    private var bitCount: Int = 0
+    private var sampleValue: UInt8 = 0x00
+}
+
+extension DMCChannel {
+    mutating public func updateRegister1(byte: UInt8) {
+        self.irqEnabled = byte[.dmcIrqEnabled] == 1
+        self.loopEnabled = byte[.dmcLoopEnabled] == 1
+        self.loopPeriod = Self.periodTable[Int(byte[.dmcPeriod])]
+    }
+
+    mutating public func updateRegister2(byte: UInt8) {
+        self.loadCounter = byte[.dmcLoadCounter]
+    }
+
+    mutating public func updateRegister3(byte: UInt8) {
+        self.sampleAddress = 0xC000 | (UInt16(byte) << 6)
+    }
+
+    mutating public func updateRegister4(byte: UInt8) {
+        self.sampleLength = (UInt16(byte) << 4) | 0x0001
+    }
+}
+
+extension DMCChannel {
+    mutating private func stepTimer() {
+        if !self.enabled {
+            return
+        }
+
+        self.stepReader()
+
+        if self.loopValue == 0 {
+            self.loopValue = self.loopPeriod
+            self.stepShifter()
+        } else {
+            self.loopValue -= 1
+        }
+    }
+
+    mutating private func restart() {
+        self.currentAddress = self.sampleAddress
+        self.currentLength = self.sampleLength
+    }
+
+    mutating private func stepReader() {
+        if self.currentLength > 0 && self.bitCount == 0 {
+            // TODO: Figure out how best to do this
+            // self.cpu.stall += 4
+
+            // TODO: Figure out how to pass in reference to CPU
+            // self.shiftRegister = self.cpu.Read(self.currentAddress)
+            self.bitCount = 8
+            self.currentAddress += 1
+            if self.currentAddress == 0 {
+                self.currentAddress = 0x8000
+            }
+
+            self.currentLength -= 1
+            if self.currentLength == 0 && self.loopEnabled {
+                self.restart()
+            }
+        }
+    }
+
+    mutating private func stepShifter() {
+        if self.bitCount == 0 {
+            return
+        }
+
+        if (self.shiftRegister & 1) == 1 {
+            if self.sampleValue <= 125 {
+                self.sampleValue += 2
+            }
+        } else {
+            if self.sampleValue >= 2 {
+                self.sampleValue -= 2
+            }
+        }
+
+        self.shiftRegister >>= 1
+        self.bitCount -= 1
+    }
+
+    private func getSample() -> UInt8 {
+        return self.sampleValue
+    }
+}

--- a/happiNESs/Interrupt.swift
+++ b/happiNESs/Interrupt.swift
@@ -1,0 +1,12 @@
+//
+//  Interrupt.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/26/24.
+//
+
+public enum Interrupt {
+    case none
+    case nmi
+    case irq
+}

--- a/happiNESs/NoiseChannel.swift
+++ b/happiNESs/NoiseChannel.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 10/24/24.
 //
 
-public enum ControlFlag {
+enum NoiseControlFlag {
     case lengthCounterEnabled
     case envelopeLoop
 }
@@ -17,27 +17,27 @@ public struct NoiseChannel {
 
     // TODO: Need comments explaining all these fields!!!
     public var enabled: Bool = false
-    public var controlFlag: ControlFlag = .lengthCounterEnabled
-    public var constantVolumeFlag: Bool = false
-    public var constantVolumeValue: UInt8 = 0x00
-    public var envelopeStart: Bool = false
-    public var envelopePeriod: UInt8 = 0x00
-    public var envelopeValue: UInt8 = 0x00
-    public var envelopeVolume: UInt8 = 0x00
-    public var mode: Int = 1
-    public var shiftRegister: UInt16 = 0x0001
-    public var timerPeriod: UInt16 = 0x0000
-    public var timerValue: UInt16 = 0x0000
+    private var controlFlag: NoiseControlFlag = .lengthCounterEnabled
+    private var constantVolumeFlag: Bool = false
+    private var constantVolume: UInt8 = 0x00
+    private var envelopeStart: Bool = false
+    private var envelopePeriod: UInt8 = 0x00
+    private var envelopeValue: UInt8 = 0x00
+    private var envelopeVolume: UInt8 = 0x00
+    private var mode: Int = 1
+    private var shiftRegister: UInt16 = 0x0001
+    private var timerPeriod: UInt16 = 0x0000
+    private var timerValue: UInt16 = 0x0000
     public var lengthCounterValue: UInt8 = 0x00
-    public var dutyIndex: Int = 0
+    private var dutyIndex: Int = 0
 }
 
 extension NoiseChannel {
     mutating public func updateRegister1(byte: UInt8) {
         self.controlFlag = byte[.noiseControlFlag] == 1 ? .envelopeLoop : .lengthCounterEnabled
-        self.constantVolumeFlag = byte[.noiseConstantVolumeFlag] != 0
+        self.constantVolumeFlag = byte[.noiseConstantVolumeFlag] == 1
         self.envelopePeriod = byte[.noiseVolume]
-        self.constantVolumeValue = byte[.noiseVolume]
+        self.constantVolume = byte[.noiseVolume]
         self.envelopeStart = true
     }
 
@@ -102,7 +102,7 @@ extension NoiseChannel {
         }
 
         if self.constantVolumeFlag {
-            return self.constantVolumeValue
+            return self.constantVolume
         } else {
             return self.envelopeVolume
         }

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -36,7 +36,7 @@ extension PPU {
         let nmiAfter = self.controllerRegister[.generateNmi]
 
         if !nmiBefore && nmiAfter && self.statusRegister[.verticalBlankStarted] {
-            self.nmiInterrupt = 1
+            self.bus!.interrupt = .nmi
         }
 
         let nametableBits = self.controllerRegister.rawValue & 0b0000_0011

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -36,7 +36,7 @@ extension PPU {
         let nmiAfter = self.controllerRegister[.generateNmi]
 
         if !nmiBefore && nmiAfter && self.statusRegister[.verticalBlankStarted] {
-            self.bus!.interrupt = .nmi
+            self.bus!.triggerNmi()
         }
 
         let nametableBits = self.controllerRegister.rawValue & 0b0000_0011

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -6,6 +6,7 @@
 //
 
 public struct PPU {
+    public var bus: Bus? = nil
     public static let width = 256
     public static let height = 240
 
@@ -37,7 +38,6 @@ public struct PPU {
 
     public var cycles: Int
     public var scanline: Int
-    public var nmiInterrupt: UInt8?
 
     public var screenBuffer: [UInt8] = [UInt8](repeating: 0x00, count: Self.width * Self.height * 3)
 
@@ -62,7 +62,6 @@ public struct PPU {
 
         self.cycles = 0
         self.scanline = 0
-        self.nmiInterrupt = nil
     }
 
     mutating public func reset() {
@@ -77,7 +76,6 @@ public struct PPU {
 
         self.cycles = 0
         self.scanline = 0
-        self.nmiInterrupt = nil
     }
 
     // Various computed properties used across multiple concerns
@@ -124,12 +122,6 @@ public struct PPU {
         self.statusRegister[.spriteZeroHit]
     }
 
-    mutating func pollNmiInterrupt() -> UInt8? {
-        let result = self.nmiInterrupt
-        self.nmiInterrupt = nil
-        return result
-    }
-
     // The return value below ultimately reflects whether or not
     // we need to redraw the screen.
     mutating func tick(cpuCycles: Int) -> Bool {
@@ -164,14 +156,14 @@ public struct PPU {
                     self.statusRegister[.verticalBlankStarted] = true
 
                     if self.controllerRegister[.generateNmi] {
-                        self.nmiInterrupt = 1
+                        self.bus!.interrupt = .nmi
                     }
 
                     redrawScreen = true
                 }
 
                 if self.isPreRenderLine {
-                    self.nmiInterrupt = nil
+                    self.bus!.interrupt = .none
                     self.statusRegister[.verticalBlankStarted] = false
                     self.statusRegister[.spriteZeroHit] = false
                 }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -76,6 +76,10 @@ public struct PPU {
 
         self.cycles = 0
         self.scanline = 0
+
+        self.nextSharedAddress = 0x0000
+        self.currentSharedAddress = 0x0000
+        self.wRegister = false
     }
 
     // Various computed properties used across multiple concerns
@@ -156,14 +160,13 @@ public struct PPU {
                     self.statusRegister[.verticalBlankStarted] = true
 
                     if self.controllerRegister[.generateNmi] {
-                        self.bus!.interrupt = .nmi
+                        self.bus!.triggerNmi()
                     }
 
                     redrawScreen = true
                 }
 
                 if self.isPreRenderLine {
-                    self.bus!.interrupt = .none
                     self.statusRegister[.verticalBlankStarted] = false
                     self.statusRegister[.spriteZeroHit] = false
                 }

--- a/happiNESs/PulseChannel.swift
+++ b/happiNESs/PulseChannel.swift
@@ -1,0 +1,56 @@
+//
+//  PulseChannel.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/17/24.
+//
+
+public struct PulseChannel {
+    public var enabled: Bool = false
+    public var controlFlagEnabled: Bool = false
+    public var sweepEnabled: Bool = false
+    public var period: UInt8 = 0x00
+    public var negate: Bool = false
+    public var shift: UInt8 = 0x00
+    public var lengthCounter: UInt8 = 0x00
+    public var timer: UInt16 = 0x0000
+    public var counterReload: UInt8 = 0x00
+}
+
+extension PulseChannel {
+//    mutating public func updateLengthCounter(byte: UInt8) {
+//        self.lengthCounter = byte
+//    }
+//
+//    mutating public func updateTimerLow(byte: UInt8) {
+//        self.timer = (self.timer & 0b0000_0111_0000_0000) | UInt16(byte)
+//    }
+//
+//    mutating public func updateTimerHigh(byte: UInt8) {
+//        self.timer = (self.timer & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
+//    }
+//
+//    mutating public func updateCounterReload(byte: UInt8) {
+//        self.counterReload = byte[.triangleCounterReload]
+//    }
+//
+//    mutating public func updateControlFlagEnabled(byte: UInt8) {
+//        self.controlFlagEnabled = byte[.triangleControlFlag] == 1
+//    }
+//
+//    mutating public func updateSweepEnabled(byte: UInt8) {
+//        self.sweepEnabled = byte[.pulseSweepEnabled] == 1
+//    }
+//
+//    mutating public func updatePeriod(byte: UInt8) {
+//        self.period = byte[.pulsePeriod]
+//    }
+//
+//    mutating public func updateNegate(byte: UInt8) {
+//        self.negate = byte[.pulseNegate] == 1
+//    }
+//
+//    mutating public func updateShift(byte: UInt8) {
+//        self.shift = byte[.pulseShift]
+//    }
+}

--- a/happiNESs/PulseChannel.swift
+++ b/happiNESs/PulseChannel.swift
@@ -16,6 +16,10 @@ enum PulseControlFlag {
 }
 
 public struct PulseChannel {
+    // NOTA BENE: Table below is a modified version of the one from
+    // the Sequencer Behavior section in the following page:
+    //
+    //     https://www.nesdev.org/wiki/APU_Pulse
     static let dutyTable: [[Bool]] = [
         [false, true, false, false, false, false, false, false],
         [false, true, true, false, false, false, false, false],

--- a/happiNESs/PulseChannel.swift
+++ b/happiNESs/PulseChannel.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 10/17/24.
 //
 
-public enum Channel {
+public enum ChannelNumber {
     case one
     case two
 }
@@ -28,7 +28,7 @@ public struct PulseChannel {
     ]
 
     public var enabled: Bool = false
-    public var channel: Channel
+    public var channelNumber: ChannelNumber
 
     private var dutyMode: Int = 0
     private var dutyIndex: Int = 0
@@ -52,8 +52,8 @@ public struct PulseChannel {
     private var timerValue: UInt16 = 0x0000
     private var counterReload: UInt8 = 0x00
 
-    public init(channel: Channel) {
-        self.channel = channel
+    public init(channelNumber: ChannelNumber) {
+        self.channelNumber = channelNumber
     }
 }
 
@@ -137,7 +137,7 @@ extension PulseChannel {
         if self.sweepNegated {
             self.timerPeriod &-= delta
 
-            if self.channel == .one {
+            if self.channelNumber == .one {
                 self.timerPeriod &-= 1
             }
         } else {

--- a/happiNESs/PulseChannel.swift
+++ b/happiNESs/PulseChannel.swift
@@ -5,52 +5,169 @@
 //  Created by Danielle Kefford on 10/17/24.
 //
 
+public enum Channel {
+    case one
+    case two
+}
+
+enum PulseControlFlag {
+    case lengthCounterEnabled
+    case envelopeLoop
+}
+
 public struct PulseChannel {
+    static let dutyTable: [[Bool]] = [
+        [false, true, false, false, false, false, false, false],
+        [false, true, true, false, false, false, false, false],
+        [false, true, true, true, true, false, false, false],
+        [true, false, false, true, true, true, true, true],
+    ]
+
     public var enabled: Bool = false
-    public var controlFlagEnabled: Bool = false
-    public var sweepEnabled: Bool = false
-    public var period: UInt8 = 0x00
-    public var negate: Bool = false
-    public var shift: UInt8 = 0x00
-    public var lengthCounter: UInt8 = 0x00
-    public var timer: UInt16 = 0x0000
-    public var counterReload: UInt8 = 0x00
+    public var channel: Channel
+
+    private var dutyMode: Int = 0
+    private var dutyIndex: Int = 0
+    private var controlFlag: PulseControlFlag = .lengthCounterEnabled
+    private var constantVolumeFlag: Bool = false
+    private var envelopeStart: Bool = false
+    private var envelopePeriod: UInt8 = 0x00
+    private var envelopeValue: UInt8 = 0x00
+    private var envelopeVolume: UInt8 = 0x00
+    private var constantVolume: UInt8 = 0x00
+
+    private var sweepReloaded: Bool = false
+    private var sweepEnabled: Bool = false
+    private var sweepPeriod: UInt8 = 0x00
+    private var sweepValue: UInt8 = 0x00
+    private var sweepNegated: Bool = false
+    private var sweepShift: UInt8 = 0x00
+
+    public var lengthCounterValue: UInt8 = 0x00
+    private var timerPeriod: UInt16 = 0x0000
+    private var timerValue: UInt16 = 0x0000
+    private var counterReload: UInt8 = 0x00
+
+    public init(channel: Channel) {
+        self.channel = channel
+    }
 }
 
 extension PulseChannel {
-//    mutating public func updateLengthCounter(byte: UInt8) {
-//        self.lengthCounter = byte
-//    }
-//
-//    mutating public func updateTimerLow(byte: UInt8) {
-//        self.timer = (self.timer & 0b0000_0111_0000_0000) | UInt16(byte)
-//    }
-//
-//    mutating public func updateTimerHigh(byte: UInt8) {
-//        self.timer = (self.timer & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
-//    }
-//
-//    mutating public func updateCounterReload(byte: UInt8) {
-//        self.counterReload = byte[.triangleCounterReload]
-//    }
-//
-//    mutating public func updateControlFlagEnabled(byte: UInt8) {
-//        self.controlFlagEnabled = byte[.triangleControlFlag] == 1
-//    }
-//
-//    mutating public func updateSweepEnabled(byte: UInt8) {
-//        self.sweepEnabled = byte[.pulseSweepEnabled] == 1
-//    }
-//
-//    mutating public func updatePeriod(byte: UInt8) {
-//        self.period = byte[.pulsePeriod]
-//    }
-//
-//    mutating public func updateNegate(byte: UInt8) {
-//        self.negate = byte[.pulseNegate] == 1
-//    }
-//
-//    mutating public func updateShift(byte: UInt8) {
-//        self.shift = byte[.pulseShift]
-//    }
+    mutating public func updateRegister1(byte: UInt8) {
+        self.dutyMode = Int(byte[.pulseDutyMode])
+        self.controlFlag = byte[.pulseControlFlag] == 1 ? .envelopeLoop : .lengthCounterEnabled
+        self.constantVolumeFlag = byte[.pulseConstantVolumeFlag] == 1
+        self.envelopePeriod = byte[.pulseVolume]
+        self.constantVolume = byte[.pulseVolume]
+        self.envelopeStart = true
+    }
+
+    mutating public func updateRegister2(byte: UInt8) {
+        self.sweepEnabled = byte[.pulseSweepEnabled] == 1
+        self.sweepPeriod = byte[.pulseSweepPeriod] + 1
+        self.sweepNegated = byte[.pulseSweepNegated] == 1
+        self.sweepShift = byte[.pulseSweepShift]
+        self.sweepReloaded = true
+    }
+
+    mutating public func updateRegister3(byte: UInt8) {
+        self.timerPeriod = (self.timerPeriod & 0b0000_0111_0000_0000) | UInt16(byte)
+    }
+
+    mutating public func updateRegister4(byte: UInt8) {
+        self.lengthCounterValue = APU.lengthTable[Int(byte[.triangleLengthCounter])]
+        self.timerPeriod = (self.timerPeriod & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
+        self.envelopeStart = true
+        self.dutyIndex = 0
+    }
+
+    mutating public func stepTimer() {
+        if self.timerValue == 0 {
+            self.timerValue = self.timerPeriod
+            self.dutyIndex = (self.dutyIndex + 1) % 8
+        } else {
+            self.timerValue -= 1
+        }
+    }
+
+    mutating public func stepEnvelope() {
+        if self.envelopeStart {
+            self.envelopeVolume = 15
+            self.envelopeValue = self.envelopePeriod
+            self.envelopeStart = false
+        } else if self.envelopeValue > 0 {
+            self.envelopeValue -= 1
+        } else {
+            if self.envelopeVolume > 0 {
+                self.envelopeVolume -= 1
+            } else if self.controlFlag == .envelopeLoop {
+                self.envelopeVolume = 15
+            }
+
+            self.envelopeValue = self.envelopePeriod
+        }
+    }
+
+    mutating public func stepSweep() {
+        if self.sweepReloaded {
+            if self.sweepEnabled && self.sweepValue == 0 {
+                self.updateTimerPeriod()
+            }
+
+            self.sweepValue = self.sweepPeriod
+            self.sweepReloaded = false
+        } else if self.sweepValue > 0 {
+            self.sweepValue -= 1
+        } else {
+            if self.sweepEnabled {
+                self.updateTimerPeriod()
+            }
+
+            self.sweepValue = self.sweepPeriod
+        }
+    }
+
+    private mutating func updateTimerPeriod() {
+        let delta = self.timerPeriod >> self.sweepShift
+        if self.sweepNegated {
+            self.timerPeriod &-= delta
+
+            if self.channel == .one {
+                self.timerPeriod &-= 1
+            }
+        } else {
+            self.timerPeriod &+= delta
+        }
+    }
+
+    mutating public func stepLength() {
+        if self.controlFlag == .lengthCounterEnabled && self.lengthCounterValue > 0 {
+            self.lengthCounterValue -= 1
+        }
+    }
+
+    public func getSample() -> UInt8 {
+        if !self.enabled {
+            return 0
+        }
+
+        if self.lengthCounterValue == 0 {
+            return 0
+        }
+
+        if Self.dutyTable[self.dutyMode][self.dutyIndex] {
+            return 0
+        }
+
+        if self.timerPeriod < 8 || self.timerPeriod > 0x7FF {
+            return 0
+        }
+
+        if self.constantVolumeFlag {
+            return self.constantVolume
+        } else {
+            return self.envelopeVolume
+        }
+    }
 }

--- a/happiNESs/Register.swift
+++ b/happiNESs/Register.swift
@@ -1,0 +1,19 @@
+//
+//  Register.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/15/24.
+//
+
+public typealias Register = UInt8
+
+extension Register {
+    subscript (_ flag: RegisterBit) -> Bool {
+        get {
+            (self & (1 << flag.bitIndex)) > 0
+        }
+        set {
+            self |= (newValue ? 1 : 0) << flag.bitIndex
+        }
+    }
+}

--- a/happiNESs/RegisterBit.swift
+++ b/happiNESs/RegisterBit.swift
@@ -36,7 +36,7 @@ enum RegisterBit {
     case apuStatusUnused2
     case apuStatusUnused3
 
-    // APU frame counter register flags
+    // APU frame sequencer register flags
     case apuFrameCounterUnused1
     case apuFrameCounterUnused2
     case apuFrameCounterUnused3
@@ -44,7 +44,7 @@ enum RegisterBit {
     case apuFrameCounterUnused5
     case apuFrameCounterUnused6
     case frameIrqInhibited
-    case frameSequencerMode
+    case sequencerMode
 
     var bitIndex: Int {
         switch self {
@@ -55,7 +55,7 @@ enum RegisterBit {
         case .break, .ppuStatusUnused5, .dmcEnabled, .apuFrameCounterUnused5: 4
         case .cpuStatusUnused, .spriteOverflow, .apuStatusUnused1, .apuFrameCounterUnused6: 5
         case .overflow, .spriteZeroHit, .apuStatusUnused2, .frameIrqInhibited: 6
-        case .negative, .verticalBlankStarted, .apuStatusUnused3, .frameSequencerMode: 7
+        case .negative, .verticalBlankStarted, .apuStatusUnused3, .sequencerMode: 7
         }
     }
 }

--- a/happiNESs/RegisterBit.swift
+++ b/happiNESs/RegisterBit.swift
@@ -1,0 +1,61 @@
+//
+//  RegisterBit.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/15/24.
+//
+
+enum RegisterBit {
+    // CPU status register flags
+    case carry
+    case zero
+    case interrupt
+    case decimalMode
+    case `break`
+    case cpuStatusUnused
+    case overflow
+    case negative
+
+    // PPU status register flags
+    case ppuStatusUnused1
+    case ppuStatusUnused2
+    case ppuStatusUnused3
+    case ppuStatusUnused4
+    case ppuStatusUnused5
+    case spriteOverflow
+    case spriteZeroHit
+    case verticalBlankStarted
+
+    // APU status register flags
+    case pulse1Enabled
+    case pulse2Enabled
+    case triangleEnabled
+    case noiseEnabled
+    case dmcEnabled
+    case apuStatusUnused1
+    case apuStatusUnused2
+    case apuStatusUnused3
+
+    // APU frame counter register flags
+    case apuFrameCounterUnused1
+    case apuFrameCounterUnused2
+    case apuFrameCounterUnused3
+    case apuFrameCounterUnused4
+    case apuFrameCounterUnused5
+    case apuFrameCounterUnused6
+    case frameIrqInhibited
+    case frameSequencerMode
+
+    var bitIndex: Int {
+        switch self {
+        case .carry, .ppuStatusUnused1, .pulse1Enabled, .apuFrameCounterUnused1: 0
+        case .zero, .ppuStatusUnused2, .pulse2Enabled, .apuFrameCounterUnused2: 1
+        case .interrupt, .ppuStatusUnused3, .triangleEnabled, .apuFrameCounterUnused3: 2
+        case .decimalMode, .ppuStatusUnused4, .noiseEnabled, .apuFrameCounterUnused4: 3
+        case .break, .ppuStatusUnused5, .dmcEnabled, .apuFrameCounterUnused5: 4
+        case .cpuStatusUnused, .spriteOverflow, .apuStatusUnused1, .apuFrameCounterUnused6: 5
+        case .overflow, .spriteZeroHit, .apuStatusUnused2, .frameIrqInhibited: 6
+        case .negative, .verticalBlankStarted, .apuStatusUnused3, .frameSequencerMode: 7
+        }
+    }
+}

--- a/happiNESs/RegisterBitMask.swift
+++ b/happiNESs/RegisterBitMask.swift
@@ -36,6 +36,12 @@ enum RegisterBitMask: Register {
     case pulseLengthCounter
     case pulseTimerHigh
 
+    case dmcIrqEnabled
+    case dmcLoopEnabled
+    case dmcPeriod
+
+    case dmcLoadCounter
+
     var maskValue: UInt8 {
         switch self {
         case .apuStatus:                   0b0001_1111
@@ -67,6 +73,12 @@ enum RegisterBitMask: Register {
 
         case .pulseLengthCounter:          0b1111_1000
         case .pulseTimerHigh:              0b0000_0111
+
+        case .dmcIrqEnabled:               0b1000_0000
+        case .dmcLoopEnabled:              0b0100_0000
+        case .dmcPeriod:                   0b0000_1111
+
+        case .dmcLoadCounter:              0b0111_1111
         }
     }
 }

--- a/happiNESs/RegisterBitMask.swift
+++ b/happiNESs/RegisterBitMask.swift
@@ -14,6 +14,15 @@ enum RegisterBitMask: Register {
     case triangleLengthCounter
     case triangleTimerHigh
 
+    case noiseControlFlag
+    case noiseConstantVolumeFlag
+    case noiseVolume
+
+    case noiseMode
+    case noisePeriod
+
+    case noiseLengthCounter
+
     case pulseSweepEnabled
     case pulsePeriod
     case pulseNegate
@@ -28,6 +37,15 @@ enum RegisterBitMask: Register {
 
         case .triangleLengthCounter:       0b1111_1000
         case .triangleTimerHigh:           0b0000_0111
+
+        case .noiseControlFlag:            0b0010_0000
+        case .noiseConstantVolumeFlag:     0b0001_0000
+        case .noiseVolume:                 0b0000_1111
+
+        case .noiseMode:                   0b1000_0000
+        case .noisePeriod:                 0b0000_1111
+
+        case .noiseLengthCounter:          0b1111_1000
 
         case .pulseSweepEnabled:           0b1000_0000
         case .pulsePeriod:                 0b0111_0000
@@ -48,7 +66,7 @@ extension Register {
         self = (self & ~(bitMask.maskValue)) | maskedBits
     }
 
-    subscript(index: RegisterBitMask) -> UInt8 {
+    subscript(_ index: RegisterBitMask) -> UInt8 {
         get {
             self.getBits(using: index)
         }

--- a/happiNESs/RegisterBitMask.swift
+++ b/happiNESs/RegisterBitMask.swift
@@ -1,0 +1,59 @@
+//
+//  RegisterBitMask.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/16/24.
+//
+
+enum RegisterBitMask: Register {
+    case apuStatus
+
+    case triangleControlFlag
+    case triangleLinearCounterReload
+
+    case triangleLengthCounter
+    case triangleTimerHigh
+
+    case pulseSweepEnabled
+    case pulsePeriod
+    case pulseNegate
+    case pulseShift
+
+    var maskValue: UInt8 {
+        switch self {
+        case .apuStatus:                   0b0001_1111
+
+        case .triangleControlFlag:         0b1000_0000
+        case .triangleLinearCounterReload: 0b0111_1111
+
+        case .triangleLengthCounter:       0b1111_1000
+        case .triangleTimerHigh:           0b0000_0111
+
+        case .pulseSweepEnabled:           0b1000_0000
+        case .pulsePeriod:                 0b0111_0000
+        case .pulseNegate:                 0b0000_1000
+        case .pulseShift:                  0b0000_0111
+        }
+    }
+}
+
+extension Register {
+    private func getBits(using bitMask: RegisterBitMask) -> UInt8 {
+        UInt8((self & bitMask.maskValue) >> bitMask.maskValue.trailingZeroBitCount)
+    }
+
+    mutating private func setBits(using bitMask: RegisterBitMask, bits: UInt8) {
+        let shiftAmount = bitMask.maskValue.trailingZeroBitCount
+        let maskedBits = (Self(bits) << shiftAmount) & bitMask.maskValue
+        self = (self & ~(bitMask.maskValue)) | maskedBits
+    }
+
+    subscript(index: RegisterBitMask) -> UInt8 {
+        get {
+            self.getBits(using: index)
+        }
+        set {
+            self.setBits(using: index, bits: newValue)
+        }
+    }
+}

--- a/happiNESs/RegisterBitMask.swift
+++ b/happiNESs/RegisterBitMask.swift
@@ -23,10 +23,18 @@ enum RegisterBitMask: Register {
 
     case noiseLengthCounter
 
+    case pulseDutyMode
+    case pulseControlFlag
+    case pulseConstantVolumeFlag
+    case pulseVolume
+
     case pulseSweepEnabled
-    case pulsePeriod
-    case pulseNegate
-    case pulseShift
+    case pulseSweepPeriod
+    case pulseSweepNegated
+    case pulseSweepShift
+
+    case pulseLengthCounter
+    case pulseTimerHigh
 
     var maskValue: UInt8 {
         switch self {
@@ -47,10 +55,18 @@ enum RegisterBitMask: Register {
 
         case .noiseLengthCounter:          0b1111_1000
 
+        case .pulseDutyMode:               0b1100_0000
+        case .pulseControlFlag:            0b0010_0000
+        case .pulseConstantVolumeFlag:     0b0001_0000
+        case .pulseVolume:                 0b0000_1111
+
         case .pulseSweepEnabled:           0b1000_0000
-        case .pulsePeriod:                 0b0111_0000
-        case .pulseNegate:                 0b0000_1000
-        case .pulseShift:                  0b0000_0111
+        case .pulseSweepPeriod:            0b0111_0000
+        case .pulseSweepNegated:           0b0000_1000
+        case .pulseSweepShift:             0b0000_0111
+
+        case .pulseLengthCounter:          0b1111_1000
+        case .pulseTimerHigh:              0b0000_0111
         }
     }
 }

--- a/happiNESs/StatusRegister.swift
+++ b/happiNESs/StatusRegister.swift
@@ -24,7 +24,7 @@ public struct StatusRegister: OptionSet {
     //  +----------------- Negative Flag
     public static let carry = Self(rawValue: 1 << 0)
     public static let zero = Self(rawValue: 1 << 1)
-    public static let interrupt = Self(rawValue: 1 << 2)
+    public static let interruptsDisabled = Self(rawValue: 1 << 2)
     public static let decimalMode = Self(rawValue: 1 << 3)
     public static let `break` = Self(rawValue: 1 << 4)
     public static let unused = Self(rawValue: 1 << 5)

--- a/happiNESs/TriangleChannel.swift
+++ b/happiNESs/TriangleChannel.swift
@@ -1,0 +1,94 @@
+//
+//  TriangleChannel.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/15/24.
+//
+
+public struct TriangleChannel {
+    private static var sampleValues: [UInt8] = [
+        15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    ]
+
+    // TODO: Need comments explaining all these fields!!!
+    public var enabled: Bool = false
+    public var controlFlagEnabled: Bool = false
+    public var linearCounterReloadFLag: Bool = false
+    public var linearCounterReload: UInt8 = 0x00
+    public var linearCounterValue: UInt8 = 0x00
+    public var lengthCounterValue: UInt8 = 0x00
+    public var timerPeriod: UInt16 = 0x0000
+    public var timerValue: UInt16 = 0x0000
+    public var dutyIndex: Int = 0
+}
+
+extension TriangleChannel {
+    mutating public func updateRegister1(byte: UInt8) {
+        self.controlFlagEnabled = byte[.triangleControlFlag] == 0
+        self.linearCounterReload = byte[.triangleLinearCounterReload]
+    }
+
+    mutating public func updateRegister3(byte: UInt8) {
+        self.timerPeriod = (self.timerPeriod & 0b0000_0111_0000_0000) | UInt16(byte)
+    }
+
+    mutating public func updateRegister4(byte: UInt8) {
+        self.lengthCounterValue = APU.lengthTable[Int(byte[.triangleLengthCounter])]
+        self.timerPeriod = (self.timerPeriod & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
+        self.timerValue = self.timerPeriod + 1
+        self.linearCounterReloadFLag = true
+    }
+
+    mutating public func stepTimer() {
+        if self.timerValue == 0 {
+            self.timerValue = self.timerPeriod + 1
+
+            if self.lengthCounterValue > 0 && self.linearCounterValue > 0 {
+                self.dutyIndex = (self.dutyIndex + 1) % Self.sampleValues.count
+            }
+        } else {
+            self.timerValue -= 1
+        }
+    }
+
+    mutating public func stepCounter() {
+        if self.linearCounterReloadFLag {
+            self.linearCounterValue = self.linearCounterReload
+        } else if self.linearCounterValue > 0 {
+            self.linearCounterValue -= 1
+        }
+
+        if self.controlFlagEnabled {
+            self.linearCounterReloadFLag = false
+        }
+    }
+
+    mutating public func stepLength() {
+        if self.controlFlagEnabled && self.lengthCounterValue > 0 {
+            self.lengthCounterValue -= 1
+        }
+    }
+
+    public func getSample() -> UInt8 {
+//        print("Duty index: \(self.dutyIndex)")
+//        print("Length counter: \(self.lengthCounterValue)")
+        if !self.enabled {
+            return 0
+        }
+
+        if self.timerPeriod < 3 {
+            return 0
+        }
+
+        if self.lengthCounterValue == 0 {
+            return 0
+        }
+
+        if self.linearCounterValue == 0 {
+            return 0
+        }
+
+        return Self.sampleValues[self.dutyIndex]
+    }
+}

--- a/happiNESs/TriangleChannel.swift
+++ b/happiNESs/TriangleChannel.swift
@@ -6,6 +6,9 @@
 //
 
 public struct TriangleChannel {
+    // NOTA BENE: Figures below taken from:
+    //
+    //     https://www.nesdev.org/wiki/APU_Triangle
     private static var sampleValues: [UInt8] = [
         15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,

--- a/happiNESs/TriangleChannel.swift
+++ b/happiNESs/TriangleChannel.swift
@@ -71,8 +71,6 @@ extension TriangleChannel {
     }
 
     public func getSample() -> UInt8 {
-//        print("Duty index: \(self.dutyIndex)")
-//        print("Length counter: \(self.lengthCounterValue)")
         if !self.enabled {
             return 0
         }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -23,6 +23,7 @@ import SwiftUI
         KeyEquivalent("s") : .buttonB,
     ]
 
+    private var speaker: Speaker
     var cartridgeLoaded: Bool = false
     var displayTimer: Timer!
 
@@ -38,6 +39,8 @@ import SwiftUI
         let bus = Bus()
         let cpu = CPU(bus: bus, tracingOn: false)
         self.cpu = cpu
+
+        self.speaker = try Speaker(inputBuffer: cpu.bus.apu.buffer)
     }
 
     public func runGame(fileUrl: URL) throws {

--- a/happiNESsApp/Speaker.swift
+++ b/happiNESsApp/Speaker.swift
@@ -1,0 +1,50 @@
+//
+//  Speaker.swift
+//  happiNESsApp
+//
+//  Created by Danielle Kefford on 10/16/24.
+//
+
+import AVFoundation
+
+import happiNESs
+
+struct Speaker {
+    public var inputBuffer: AudioRingBuffer
+
+    init(inputBuffer: AudioRingBuffer) throws {
+        self.inputBuffer = inputBuffer
+
+        let engine = AVAudioEngine()
+        let mainMixer = engine.mainMixerNode
+        let output = engine.outputNode
+        let outputFormat = output.inputFormat(forBus: 0)
+        let sampleRate = Float(outputFormat.sampleRate)
+        let inputFormat = AVAudioFormat(commonFormat: outputFormat.commonFormat,
+                                        sampleRate: outputFormat.sampleRate,
+                                        channels: 1,
+                                        interleaved: outputFormat.isInterleaved)
+
+        let sourceNode = AVAudioSourceNode { [inputBuffer] _, _, frameCount, audioBufferList -> OSStatus in
+            let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
+
+            for frame in 0..<Int(frameCount) {
+                let value = inputBuffer.take() ?? 0.0
+
+                for outputAudioBuffer in ablPointer {
+                    let outputBuffer: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(outputAudioBuffer)
+                    outputBuffer[frame] = value
+                }
+            }
+
+            return noErr
+        }
+
+        engine.attach(sourceNode)
+        engine.connect(sourceNode, to: mainMixer, format: inputFormat)
+        engine.connect(mainMixer, to: output, format: outputFormat)
+        mainMixer.outputVolume = 0.5
+
+        try engine.start()
+    }
+}

--- a/happiNESsApp/Speaker.swift
+++ b/happiNESsApp/Speaker.swift
@@ -11,11 +11,11 @@ import happiNESs
 
 struct Speaker {
     public var inputBuffer: AudioRingBuffer
+    private let engine = AVAudioEngine()
 
     init(inputBuffer: AudioRingBuffer) throws {
         self.inputBuffer = inputBuffer
 
-        let engine = AVAudioEngine()
         let mainMixer = engine.mainMixerNode
         let output = engine.outputNode
         let outputFormat = output.inputFormat(forBus: 0)

--- a/happiNESsTests/CPUTests.swift
+++ b/happiNESsTests/CPUTests.swift
@@ -417,7 +417,7 @@ final class CPUTests: XCTestCase {
         var cpu = makeCpu(programBytes: program)
         cpu.executeInstructions(stoppingAfter: 4)
 
-        XCTAssertTrue(!cpu.statusRegister[.interrupt])
+        XCTAssertTrue(!cpu.statusRegister[.interruptsDisabled])
     }
 
     func testClv() {
@@ -1176,7 +1176,7 @@ final class CPUTests: XCTestCase {
         XCTAssertTrue(cpu.statusRegister[.negative])
         XCTAssertTrue(cpu.statusRegister[.overflow])
         XCTAssertTrue(!cpu.statusRegister[.break])
-        XCTAssertTrue(cpu.statusRegister[.interrupt])
+        XCTAssertTrue(cpu.statusRegister[.interruptsDisabled])
         XCTAssertTrue(cpu.statusRegister[.zero])
         XCTAssertTrue(cpu.statusRegister[.carry])
     }
@@ -1469,7 +1469,7 @@ final class CPUTests: XCTestCase {
         var cpu = makeCpu(programBytes: program)
         cpu.executeInstructions(stoppingAfter: 4)
 
-        XCTAssertTrue(cpu.statusRegister[.interrupt])
+        XCTAssertTrue(cpu.statusRegister[.interruptsDisabled])
     }
 
     func testStaZeroPage() {


### PR DESCRIPTION
This PR introduces a fairly comprehensive implementation of an APU, which finally adds sound and music capabilities to happiNESs. The following changes are included in this PR:

* A new `Register` type alias with subscripting, new `RegisterBit` enum, and new `RegisterBitMask` type, which all make bit twiddling _much_ easier than making more specialized structs like `StatusRegister` which conform to `OptionSet`
* A new `APU` struct that has four new channel types, each of which provides various stepper functions and a `getSample()` method called throughout each CPU cycle.
  * two instances of `PulseChannel`
  * a `TriangleChannel`
  * a `NoiseChannel`
  * a `DMCChannel`
* The `APU` does the following:
  * responds to various write requests at addresses 0x4000 through 0x4017
  * responds to `CPU` ticks similar to how the `PPU` does but performs the following at various points in each cycle:
    * steps through the timers for each channel
    * steps the sequencers for each channel
    * writes a `Float` value to the buffer
* A new `Speaker` struct which houses all the machinery from the AVFoundation framework to provide sound
* A new `AudioRingBuffer` class which houses a fixed array of bytes to be written to and read from. It maintains indices for reading and writing such that any time the buffer has no more new values to return for a `take()` request, it returns `nil`. In other words, the read index, never overtakes the write index. A single instance is created in the APU and is then shared with the `Speaker` (when `Console` is initialized); the former writes to it as necessary, and the latter reads from it in order to produce sound. (It does this by the closure that is passed to the `AVAudioSourceNode` instance and closes over the buffer reference value.)
* `CPU` and `Bus` are now classes in order to be able to allow for bidirectional communication between components, specifically for two reasons:
  * A new interrupt type, namely and IRQ interrupt needs to be generated, specifically, by the `DMCChannel` instance at certain cycles, and be handled by the `CPU`.
  * The `DMCChannel` also needs to be able to read from the `Bus` in order to get sound samples from CHR ROM.

  Previously, the `CPU` polled the `Bus` instance to see if an NMI interrupt had been made, but this model quickly breaks down with the need for a more general interrupt handler. And so, in addition to being made classes, and references being threaded through to the `APU` and `DMCChannel`, there is a new `Interrupt` enum and the `CPU` now owns the interrupt status instead of the `Bus`.

It should be noted that a good portion of the implementation here is modeled on that of Michael Fogelman's excellent emulator. That said, there are significant differences between the two, sometimes because there are different idioms in Swift than in Go, other times I wanted this code to be more in alignment from what I gathered from the documentation in the NESDev wiki.