### PR TITLE
Refactoring `Cartridge`

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -67,7 +67,12 @@
 		878D81482C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878DCB8D2CCAB4CC00BE7ABB /* NoiseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */; };
 		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
-		87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* Mapper.swift */; };
+		87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* MapperNumber.swift */; };
+		87E981472CD076660090A200 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981462CD076660090A200 /* Mapper.swift */; };
+		87E981492CD0772A0090A200 /* Nrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981482CD0772A0090A200 /* Nrom.swift */; };
+		87E9814B2CD0916A0090A200 /* Cnrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814A2CD0916A0090A200 /* Cnrom.swift */; };
+		87E9814D2CD098680090A200 /* Uxrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814C2CD098680090A200 /* Uxrom.swift */; };
+		87E9814F2CD09BF70090A200 /* Axrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814E2CD09BF70090A200 /* Axrom.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -160,7 +165,12 @@
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
 		878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseChannel.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
-		87D265162C9DECAF00C143B1 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
+		87D265162C9DECAF00C143B1 /* MapperNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapperNumber.swift; sourceTree = "<group>"; };
+		87E981462CD076660090A200 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
+		87E981482CD0772A0090A200 /* Nrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nrom.swift; sourceTree = "<group>"; };
+		87E9814A2CD0916A0090A200 /* Cnrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cnrom.swift; sourceTree = "<group>"; };
+		87E9814C2CD098680090A200 /* Uxrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uxrom.swift; sourceTree = "<group>"; };
+		87E9814E2CD09BF70090A200 /* Axrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Axrom.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -267,7 +277,8 @@
 				8771BFA72CCD62C500306E13 /* Interrupt.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
-				87D265162C9DECAF00C143B1 /* Mapper.swift */,
+				87E981462CD076660090A200 /* Mapper.swift */,
+				87D265162C9DECAF00C143B1 /* MapperNumber.swift */,
 				87184D092C7511F90003D090 /* MaskRegister.swift */,
 				871932112C37985700A73C22 /* Mirroring.swift */,
 				871932062C30E91D00A73C22 /* NESColor.swift */,
@@ -307,6 +318,10 @@
 		8771BFA92CD03E6200306E13 /* Mappers */ = {
 			isa = PBXGroup;
 			children = (
+				87E9814E2CD09BF70090A200 /* Axrom.swift */,
+				87E9814A2CD0916A0090A200 /* Cnrom.swift */,
+				87E981482CD0772A0090A200 /* Nrom.swift */,
+				87E9814C2CD098680090A200 /* Uxrom.swift */,
 			);
 			path = Mappers;
 			sourceTree = "<group>";
@@ -472,6 +487,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */,
+				87E9814D2CD098680090A200 /* Uxrom.swift in Sources */,
 				870AABDC2CB3533700E9F3B6 /* PPU+IO.swift in Sources */,
 				870AABDE2CB36D4100E9F3B6 /* PPU+rendering.swift in Sources */,
 				870AABE22CB381C100E9F3B6 /* CPU+memory.swift in Sources */,
@@ -490,6 +506,7 @@
 				871932052C30C6DC00A73C22 /* JoypadButton.swift in Sources */,
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,
+				87E981472CD076660090A200 /* Mapper.swift in Sources */,
 				874F51AB2CBF036600B12037 /* RegisterBit.swift in Sources */,
 				870AABE42CB382E000E9F3B6 /* CPU+execution.swift in Sources */,
 				87184D052C7028F10003D090 /* PPUStatusRegister.swift in Sources */,
@@ -501,16 +518,19 @@
 				87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */,
 				874F51AF2CBF10DA00B12037 /* TriangleChannel.swift in Sources */,
 				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
-				87D265172C9DECAF00C143B1 /* Mapper.swift in Sources */,
+				87E981492CD0772A0090A200 /* Nrom.swift in Sources */,
+				87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
 				878D81472C815E760076ED30 /* NESError.swift in Sources */,
 				870AABDA2CB34E3000E9F3B6 /* PPU+tracing.swift in Sources */,
 				877E970B2C7E4716007513B5 /* Joypad.swift in Sources */,
 				870AABD82CB32FAA00E9F3B6 /* PPU+caching.swift in Sources */,
+				87E9814B2CD0916A0090A200 /* Cnrom.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
 				874F51B12CC03F1500B12037 /* RegisterBitMask.swift in Sources */,
 				874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */,
 				874F51B52CC1D05D00B12037 /* PulseChannel.swift in Sources */,
+				87E9814F2CD09BF70090A200 /* Axrom.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		8744B1742C1CB9B3001B44B5 /* happiNESs */ = {
 			isa = PBXGroup;
 			children = (
+				8771BFA92CD03E6200306E13 /* Mappers */,
 				8744B1752C1CB9B3001B44B5 /* happiNESs.h */,
 				8744B1762C1CB9B3001B44B5 /* happiNESs.docc */,
 				878C69722CAA424400DA9BD4 /* Address.swift */,
@@ -301,6 +302,13 @@
 				8763D0692C39B719006C1B4F /* RomTests.swift */,
 			);
 			path = happiNESsTests;
+			sourceTree = "<group>";
+		};
+		8771BFA92CD03E6200306E13 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Mappers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -47,10 +47,6 @@ public class Bus {
 }
 
 extension Bus {
-    private func readPrg(address: UInt16) -> UInt8 {
-        return self.cartridge!.readPrg(address: address)
-    }
-
     // NOTA BENE: Called directly by the tracer, as well as by readByte()
     func readByteWithoutMutating(address: UInt16) -> UInt8 {
         switch address {
@@ -71,7 +67,7 @@ extension Bus {
         case 0x4016:
             return self.joypad.readByteWithoutMutating()
         case 0x8000 ... 0xFFFF:
-            return self.readPrg(address: address)
+            return self.cartridge!.readByte(address: address)
         default:
             // TODO: Implement memory reading from these addresses?
             return 0x00

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -61,6 +61,18 @@ public class Cartridge {
         self.chrBankIndex = 0
     }
 
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            return mapper.readChr(address: address, cartridge: self)
+        case 0x8000 ... 0xFFFF:
+            return mapper.readPrg(address: address, cartridge: self)
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
     public func writeByte(address: UInt16, byte: UInt8) {
         switch self.mapper {
         case .nrom:
@@ -76,17 +88,17 @@ public class Cartridge {
         }
     }
 
-    public func readPrg(address: UInt16) -> UInt8 {
-        mapper.readPrg(address: address, cartridge: self)
-    }
+//    public func readPrg(address: UInt16) -> UInt8 {
+//        mapper.readPrg(address: address, cartridge: self)
+//    }
 
     public func writePrg(address: UInt16, byte: UInt8) {
         mapper.writePrg(address: address, byte: byte, cartridge: self)
     }
 
-    public func readChr(address: UInt16) -> UInt8 {
-        mapper.readChr(address: address, cartridge: self)
-    }
+//    public func readChr(address: UInt16) -> UInt8 {
+//        mapper.readChr(address: address, cartridge: self)
+//    }
 
     public func readTileFromChr(startAddress: UInt16) -> ArraySlice<UInt8> {
         mapper.readTileFromChr(startAddress: startAddress, cartridge: self)

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -74,37 +74,24 @@ public class Cartridge {
     }
 
     public func writeByte(address: UInt16, byte: UInt8) {
-        switch self.mapper {
-        case .nrom:
-            break
-        case .uxrom:
-            self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
-        case .cnrom:
-            self.mapper.setChrBankIndex(byte: byte, cartridge: self)
-        case .axrom:
-            let mirrorBit = (byte & 0b0001_0000) >> 4
-            self.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
-            self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            self.mapper.writeChr(address: address, byte: byte, cartridge: self)
+        case 0x8000 ... 0xFFFF:
+            switch self.mapper {
+            case .nrom:
+                break
+            case .uxrom:
+                self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
+            case .cnrom:
+                self.mapper.setChrBankIndex(byte: byte, cartridge: self)
+            case .axrom:
+                self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
+                let mirrorBit = (byte & 0b0001_0000) >> 4
+                self.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
+            }
+        default:
+            print("Attempted to write to cartridge at address: \(address)")
         }
-    }
-
-//    public func readPrg(address: UInt16) -> UInt8 {
-//        mapper.readPrg(address: address, cartridge: self)
-//    }
-
-    public func writePrg(address: UInt16, byte: UInt8) {
-        mapper.writePrg(address: address, byte: byte, cartridge: self)
-    }
-
-//    public func readChr(address: UInt16) -> UInt8 {
-//        mapper.readChr(address: address, cartridge: self)
-//    }
-
-    public func readTileFromChr(startAddress: UInt16) -> ArraySlice<UInt8> {
-        mapper.readTileFromChr(startAddress: startAddress, cartridge: self)
-    }
-
-    public func writeChr(address: UInt16, byte: UInt8) {
-        mapper.writeChr(address: address, byte: byte, cartridge: self)
     }
 }

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -36,10 +36,10 @@ public class Cartridge {
         }
 
         let mapperNumber = (bytes[7] & 0b1111_0000) | (bytes[6] >> 4)
-        guard let mapper = Mapper(rawValue: mapperNumber) else {
+        guard let mapperNumber = MapperNumber(rawValue: mapperNumber) else {
             throw NESError.mapperNotSupported(Int(mapperNumber))
         }
-        self.mapper = mapper
+        self.mapper = mapperNumber.makeMapper()
 
         let prgRomSize = Int(bytes[4]) * Self.prgMemoryPageSize
         let chrRomSize = Int(bytes[5]) * Self.chrMemoryPageSize
@@ -54,44 +54,19 @@ public class Cartridge {
         }
 
         self.mirroring = mirroring
-        self.mapper = mapper
         self.prgMemory = prgMemory
         self.prgBankIndex = 0
         self.chrMemory = chrMemory
         self.chrBankIndex = 0
+
+        self.mapper.cartridge = self
     }
 
     public func readByte(address: UInt16) -> UInt8 {
-        switch address {
-        case 0x0000 ... 0x1FFF:
-            return mapper.readChr(address: address, cartridge: self)
-        case 0x8000 ... 0xFFFF:
-            return mapper.readPrg(address: address, cartridge: self)
-        default:
-            print("Attempted to read cartridge at address: \(address)")
-            return 0x00
-        }
+        return self.mapper.readByte(address: address)
     }
 
     public func writeByte(address: UInt16, byte: UInt8) {
-        switch address {
-        case 0x0000 ... 0x1FFF:
-            self.mapper.writeChr(address: address, byte: byte, cartridge: self)
-        case 0x8000 ... 0xFFFF:
-            switch self.mapper {
-            case .nrom:
-                break
-            case .uxrom:
-                self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
-            case .cnrom:
-                self.mapper.setChrBankIndex(byte: byte, cartridge: self)
-            case .axrom:
-                self.mapper.setPrgBankIndex(byte: byte, cartridge: self)
-                let mirrorBit = (byte & 0b0001_0000) >> 4
-                self.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
-            }
-        default:
-            print("Attempted to write to cartridge at address: \(address)")
-        }
+        self.mapper.writeByte(address: address, byte: byte)
     }
 }

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -69,13 +69,6 @@ public enum Mapper: UInt8 {
         }
     }
 
-    public func writePrg(address: UInt16, byte: UInt8, cartridge: Cartridge) {
-        switch self {
-        case .nrom, .uxrom, .cnrom, .axrom:
-            logIgnoredWrite(address: address, byte: byte, inChr: false)
-        }
-    }
-
     private func chrMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
         switch self {
         case .nrom, .uxrom, .axrom:
@@ -100,11 +93,6 @@ public enum Mapper: UInt8 {
     public func readChr(address: UInt16, cartridge: Cartridge) -> UInt8 {
         let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
         return cartridge.chrMemory[memoryIndex]
-    }
-
-    public func readTileFromChr(startAddress: UInt16, cartridge: Cartridge) -> ArraySlice<UInt8> {
-        let startMemoryIndex = self.chrMemoryIndex(for: startAddress, cartridge: cartridge)
-        return cartridge.chrMemory[startMemoryIndex ..< startMemoryIndex + 16]
     }
 
     public func writeChr(address: UInt16, byte: UInt8, cartridge: Cartridge) {

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -2,106 +2,12 @@
 //  Mapper.swift
 //  happiNESs
 //
-//  Created by Danielle Kefford on 9/20/24.
+//  Created by Danielle Kefford on 10/28/24.
 //
 
-public enum Mapper: UInt8 {
-    case nrom = 0
-    case uxrom = 2
-    case cnrom = 3
-    case axrom = 7
+public protocol Mapper {
+    var cartridge: Cartridge? { get set }
 
-    private func logIgnoredWrite(address: UInt16, byte: UInt8, inChr: Bool) {
-        print(String(format: "Ignored write of %0x to %0x in \(inChr ? "CHR" : "PRG")", byte, address))
-    }
-
-    private func prgMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
-        switch self {
-        case .nrom, .cnrom:
-            return Int(address)
-        case .uxrom:
-            switch address {
-            case 0x8000 ... 0xBFFF:
-                return cartridge.prgBankIndex * 0x4000 + Int(address - 0x8000)
-            case 0xC000 ... 0xFFFF:
-                let lastBankStart = 7 * 0x4000
-                return lastBankStart + Int(address - 0xC000)
-            default:
-                fatalError("Whoops! tried addressing PRG memory out of range")
-            }
-        case .axrom:
-            switch address {
-            case 0x8000 ... 0xFFFF:
-                return cartridge.prgBankIndex * 0x8000 + Int(address - 0x8000)
-            default:
-                fatalError("Whoops! tried addressing PRG memory out of range")
-            }
-        }
-    }
-
-    public func setPrgBankIndex(byte: UInt8, cartridge: Cartridge) {
-        switch self {
-        case .nrom, .cnrom:
-            break
-        case .uxrom:
-            let bankIndex = byte & 0b0000_1111
-            cartridge.prgBankIndex = Int(bankIndex)
-        case .axrom:
-            let bankIndex = byte & 0b0000_0111
-            cartridge.prgBankIndex = Int(bankIndex)
-        }
-    }
-
-    public func readPrg(address: UInt16, cartridge: Cartridge) -> UInt8 {
-        switch self {
-        case .nrom, .cnrom:
-            var addressOffset = address - 0x8000
-
-            // Mirror if needed
-            if cartridge.prgMemory.count == 0x4000 {
-                addressOffset = addressOffset % 0x4000
-            }
-
-            return cartridge.prgMemory[Int(addressOffset)]
-        case .uxrom, .axrom:
-            let memoryIndex = self.prgMemoryIndex(for: address, cartridge: cartridge)
-            return cartridge.prgMemory[memoryIndex]
-        }
-    }
-
-    private func chrMemoryIndex(for address: UInt16, cartridge: Cartridge) -> Int {
-        switch self {
-        case .nrom, .uxrom, .axrom:
-            return Int(address)
-        case .cnrom:
-            return cartridge.chrBankIndex * 0x2000 + Int(address)
-        }
-    }
-
-    public func setChrBankIndex(byte: UInt8, cartridge: Cartridge) {
-        switch self {
-        case .nrom, .uxrom, .axrom:
-            // For some reason Ms. Pacman calls this even though there is
-            // no bank switching for NROM games, so for now just ignore it.
-            break
-        case .cnrom:
-            let bankIndex = byte & 0b0000_0011
-            cartridge.chrBankIndex = Int(bankIndex)
-        }
-    }
-
-    public func readChr(address: UInt16, cartridge: Cartridge) -> UInt8 {
-        let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
-        return cartridge.chrMemory[memoryIndex]
-    }
-
-    public func writeChr(address: UInt16, byte: UInt8, cartridge: Cartridge) {
-        switch self {
-        case .nrom, .cnrom:
-            logIgnoredWrite(address: address, byte: byte, inChr: true)
-        case .uxrom, .axrom:
-            let memoryIndex = self.chrMemoryIndex(for: address, cartridge: cartridge)
-            cartridge.chrMemory[memoryIndex] = byte
-        }
-    }
+    func readByte(address: UInt16) -> UInt8
+    func writeByte(address: UInt16, byte: UInt8)
 }

--- a/happiNESs/MapperNumber.swift
+++ b/happiNESs/MapperNumber.swift
@@ -1,0 +1,26 @@
+//
+//  MapperNumber.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 9/20/24.
+//
+
+public enum MapperNumber: UInt8 {
+    case nrom = 0
+    case uxrom = 2
+    case cnrom = 3
+    case axrom = 7
+
+    public func makeMapper() -> Mapper {
+        switch self {
+        case .nrom:
+            return Nrom()
+        case .uxrom:
+            return Uxrom()
+        case .cnrom:
+            return Cnrom()
+        case .axrom:
+            return Axrom()
+        }
+    }
+}

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -1,0 +1,40 @@
+//
+//  Axrom.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/28/24.
+//
+
+struct Axrom: Mapper {
+    public var cartridge: Cartridge? = nil
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = Int(address)
+            return cartridge!.chrMemory[memoryIndex]
+        case 0x8000 ... 0xFFFF:
+            let memoryIndex = cartridge!.prgBankIndex * 0x8000 + Int(address - 0x8000)
+            return cartridge!.prgMemory[Int(memoryIndex)]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = Int(address)
+            cartridge!.chrMemory[memoryIndex] = byte
+        case 0x8000 ... 0xFFFF:
+            let bankIndex = byte & 0b0000_0111
+            cartridge!.prgBankIndex = Int(bankIndex)
+
+            let mirrorBit = (byte & 0b0001_0000) >> 4
+            self.cartridge!.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
+        default:
+            print("Attempted to write to NROM cartridge at address: \(address)")
+        }
+    }
+}

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -1,0 +1,42 @@
+//
+//  Uxrom.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/28/24.
+//
+
+struct Cnrom: Mapper {
+    public var cartridge: Cartridge? = nil
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = cartridge!.chrBankIndex * 0x2000 + Int(address)
+            return cartridge!.chrMemory[memoryIndex]
+        case 0x8000 ... 0xFFFF:
+            var memoryIndex = address - 0x8000
+
+            // Mirror if needed
+            if cartridge!.prgMemory.count == 0x4000 {
+                memoryIndex = memoryIndex % 0x4000
+            }
+
+            return cartridge!.prgMemory[Int(memoryIndex)]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            break
+        case 0x8000 ... 0xFFFF:
+            let bankIndex = byte & 0b0000_0011
+            self.cartridge!.chrBankIndex = Int(bankIndex)
+        default:
+            print("Attempted to write to NROM cartridge at address: \(address)")
+        }
+    }
+}

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -1,0 +1,42 @@
+//
+//  Nrom.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/28/24.
+//
+
+struct Nrom: Mapper {
+    public var cartridge: Cartridge? = nil
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = Int(address)
+            return cartridge!.chrMemory[memoryIndex]
+        case 0x8000 ... 0xFFFF:
+            var memoryIndex = address - 0x8000
+
+            // Mirror if needed
+            if cartridge!.prgMemory.count == 0x4000 {
+                memoryIndex = memoryIndex % 0x4000
+            }
+
+            return cartridge!.prgMemory[Int(memoryIndex)]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    public func writeByte(address: UInt16, byte: UInt8) {
+        // NOTA BENE: No writes expected for this ROM type
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            break
+        case 0x8000 ... 0xFFFF:
+            break
+        default:
+            print("Attempted to write to NROM cartridge at address: \(address)")
+        }
+    }
+}

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -1,0 +1,41 @@
+//
+//  Uxrom.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/28/24.
+//
+
+struct Uxrom: Mapper {
+    public var cartridge: Cartridge? = nil
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = Int(address)
+            return cartridge!.chrMemory[memoryIndex]
+        case 0x8000 ... 0xBFFF:
+            let memoryIndex = cartridge!.prgBankIndex * 0x4000 + Int(address - 0x8000)
+            return cartridge!.prgMemory[Int(memoryIndex)]
+        case 0xC000 ... 0xFFFF:
+            let lastBankStart = 7 * 0x4000
+            let memoryIndex = lastBankStart + Int(address - 0xC000)
+            return cartridge!.prgMemory[Int(memoryIndex)]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let memoryIndex = Int(address)
+            cartridge!.chrMemory[memoryIndex] = byte
+        case 0x8000 ... 0xFFFF:
+            let bankIndex = byte & 0b0000_1111
+            cartridge!.prgBankIndex = Int(bankIndex)
+        default:
+            print("Attempted to write to NROM cartridge at address: \(address)")
+        }
+    }
+}

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -192,7 +192,7 @@ extension PPU {
         let mirroredAddress = address % 0x4000
         switch mirroredAddress {
         case 0x0000 ... 0x1FFF:
-            return (self.cartridge!.readChr(address: mirroredAddress), true)
+            return (self.cartridge!.readByte(address: mirroredAddress), true)
         case 0x2000 ... 0x3EFF:
             return (self.vram[self.vramIndex(from: mirroredAddress)], true)
         case 0x3F00 ... 0x3FFF:

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -231,7 +231,7 @@ extension PPU {
 
         switch address {
         case 0x0000 ... 0x1FFF:
-            self.cartridge!.writeChr(address: address, byte: byte)
+            self.cartridge!.writeByte(address: address, byte: byte)
         case 0x2000 ... 0x3EFF:
             self.vram[self.vramIndex(from: address)] = byte
         case 0x3F00 ... 0x3FFF:


### PR DESCRIPTION
This PR moves out all the memory handling logic out of `Cartridge` and the original `Mapper` enum, and moves it all into separate structs, each conforming to the new `Mapper` protocol. This makes is _much_ easier to understand how each mapper works, and to add new ones. Additionally, up until now the four mappers that have been implement share the same pieces of state managed in `Cartridge`, but other mappers such as 001 involve new pieces of state, and it does not make sense to keep adding them to `Cartridge` when the other mappers will never use them. It makes more sense for each mapper to manage its own state that is only relevant to itself.

Upon initialization, `Cartridge` will determine the mapper number by using the new `MapperNumber` enum, and then call `makeMapper()` to create and store a mutable copy of it locally. Additionally, The `Bus` and `PPU` retain their references to `Cartridge` but call `readByte()` and `writeByte()` of the current `Mapper` instance, instead of directly accessing PRG and CHR memory.