### PR TITLE
Implement mapper 001 (MMC1)

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		87E9814B2CD0916A0090A200 /* Cnrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814A2CD0916A0090A200 /* Cnrom.swift */; };
 		87E9814D2CD098680090A200 /* Uxrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814C2CD098680090A200 /* Uxrom.swift */; };
 		87E9814F2CD09BF70090A200 /* Axrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E9814E2CD09BF70090A200 /* Axrom.swift */; };
+		87E981512CD0C45A0090A200 /* Mmc1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981502CD0C45A0090A200 /* Mmc1.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -171,6 +172,7 @@
 		87E9814A2CD0916A0090A200 /* Cnrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cnrom.swift; sourceTree = "<group>"; };
 		87E9814C2CD098680090A200 /* Uxrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uxrom.swift; sourceTree = "<group>"; };
 		87E9814E2CD09BF70090A200 /* Axrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Axrom.swift; sourceTree = "<group>"; };
+		87E981502CD0C45A0090A200 /* Mmc1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mmc1.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -320,6 +322,7 @@
 			children = (
 				87E9814E2CD09BF70090A200 /* Axrom.swift */,
 				87E9814A2CD0916A0090A200 /* Cnrom.swift */,
+				87E981502CD0C45A0090A200 /* Mmc1.swift */,
 				87E981482CD0772A0090A200 /* Nrom.swift */,
 				87E9814C2CD098680090A200 /* Uxrom.swift */,
 			);
@@ -519,6 +522,7 @@
 				874F51AF2CBF10DA00B12037 /* TriangleChannel.swift in Sources */,
 				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
 				87E981492CD0772A0090A200 /* Nrom.swift in Sources */,
+				87E981512CD0C45A0090A200 /* Mmc1.swift in Sources */,
 				87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */,
 				871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */,
 				878D81472C815E760076ED30 /* NESError.swift in Sources */,

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -12,11 +12,12 @@ public class Cartridge {
 
     public var mirroring: Mirroring
     public var mapperNumber: MapperNumber
-    public var mapper: Mapper?
     public var prgMemory: [UInt8]
     public var prgBankIndex: Int
     public var chrMemory: [UInt8]
     public var chrBankIndex: Int
+
+    public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self)
 
     public init(bytes: [UInt8]) throws {
         if Array(bytes[0..<4]) != Self.nesTag {
@@ -62,10 +63,10 @@ public class Cartridge {
     }
 
     public func readByte(address: UInt16) -> UInt8 {
-        return self.mapper!.readByte(address: address)
+        return self.mapper.readByte(address: address)
     }
 
     public func writeByte(address: UInt16, byte: UInt8) {
-        self.mapper!.writeByte(address: address, byte: byte)
+        self.mapper.writeByte(address: address, byte: byte)
     }
 }

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -11,7 +11,8 @@ public class Cartridge {
     static let chrMemoryPageSize: Int = 8192
 
     public var mirroring: Mirroring
-    public var mapper: Mapper
+    public var mapperNumber: MapperNumber
+    public var mapper: Mapper?
     public var prgMemory: [UInt8]
     public var prgBankIndex: Int
     public var chrMemory: [UInt8]
@@ -35,11 +36,11 @@ public class Cartridge {
         case (false, false): .horizontal
         }
 
-        let mapperNumber = (bytes[7] & 0b1111_0000) | (bytes[6] >> 4)
-        guard let mapperNumber = MapperNumber(rawValue: mapperNumber) else {
-            throw NESError.mapperNotSupported(Int(mapperNumber))
+        let mapperByte = (bytes[7] & 0b1111_0000) | (bytes[6] >> 4)
+        guard let mapperNumber = MapperNumber(rawValue: mapperByte) else {
+            throw NESError.mapperNotSupported(Int(mapperByte))
         }
-        self.mapper = mapperNumber.makeMapper()
+        self.mapperNumber = mapperNumber
 
         let prgRomSize = Int(bytes[4]) * Self.prgMemoryPageSize
         let chrRomSize = Int(bytes[5]) * Self.chrMemoryPageSize
@@ -58,15 +59,13 @@ public class Cartridge {
         self.prgBankIndex = 0
         self.chrMemory = chrMemory
         self.chrBankIndex = 0
-
-        self.mapper.cartridge = self
     }
 
     public func readByte(address: UInt16) -> UInt8 {
-        return self.mapper.readByte(address: address)
+        return self.mapper!.readByte(address: address)
     }
 
     public func writeByte(address: UInt16, byte: UInt8) {
-        self.mapper.writeByte(address: address, byte: byte)
+        self.mapper!.writeByte(address: address, byte: byte)
     }
 }

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -6,8 +6,8 @@
 //
 
 public protocol Mapper {
-    var cartridge: Cartridge? { get set }
+    var cartridge: Cartridge { get }
 
     func readByte(address: UInt16) -> UInt8
-    func writeByte(address: UInt16, byte: UInt8)
+    mutating func writeByte(address: UInt16, byte: UInt8)
 }

--- a/happiNESs/MapperNumber.swift
+++ b/happiNESs/MapperNumber.swift
@@ -7,20 +7,23 @@
 
 public enum MapperNumber: UInt8 {
     case nrom = 0
+    case mmc1 = 1
     case uxrom = 2
     case cnrom = 3
     case axrom = 7
 
-    public func makeMapper() -> Mapper {
+    public func makeMapper(cartridge: Cartridge) -> Mapper {
         switch self {
         case .nrom:
-            return Nrom()
+            return Nrom(cartridge: cartridge)
+        case .mmc1:
+            return Mmc1(cartridge: cartridge)
         case .uxrom:
-            return Uxrom()
+            return Uxrom(cartridge: cartridge)
         case .cnrom:
-            return Cnrom()
+            return Cnrom(cartridge: cartridge)
         case .axrom:
-            return Axrom()
+            return Axrom(cartridge: cartridge)
         }
     }
 }

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -6,16 +6,16 @@
 //
 
 struct Axrom: Mapper {
-    public var cartridge: Cartridge? = nil
+    public var cartridge: Cartridge
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
-            return cartridge!.chrMemory[memoryIndex]
+            return cartridge.chrMemory[memoryIndex]
         case 0x8000 ... 0xFFFF:
-            let memoryIndex = cartridge!.prgBankIndex * 0x8000 + Int(address - 0x8000)
-            return cartridge!.prgMemory[Int(memoryIndex)]
+            let memoryIndex = cartridge.prgBankIndex * 0x8000 + Int(address - 0x8000)
+            return cartridge.prgMemory[Int(memoryIndex)]
         default:
             print("Attempted to read cartridge at address: \(address)")
             return 0x00
@@ -26,13 +26,13 @@ struct Axrom: Mapper {
         switch address {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
-            cartridge!.chrMemory[memoryIndex] = byte
+            cartridge.chrMemory[memoryIndex] = byte
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_0111
-            cartridge!.prgBankIndex = Int(bankIndex)
+            cartridge.prgBankIndex = Int(bankIndex)
 
             let mirrorBit = (byte & 0b0001_0000) >> 4
-            self.cartridge!.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
+            self.cartridge.mirroring = mirrorBit == 1 ? .singleScreen1 : .singleScreen0
         default:
             print("Attempted to write to NROM cartridge at address: \(address)")
         }

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -6,22 +6,22 @@
 //
 
 struct Cnrom: Mapper {
-    public var cartridge: Cartridge? = nil
+    public var cartridge: Cartridge
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
         case 0x0000 ... 0x1FFF:
-            let memoryIndex = cartridge!.chrBankIndex * 0x2000 + Int(address)
-            return cartridge!.chrMemory[memoryIndex]
+            let memoryIndex = self.cartridge.chrBankIndex * 0x2000 + Int(address)
+            return self.cartridge.chrMemory[memoryIndex]
         case 0x8000 ... 0xFFFF:
             var memoryIndex = address - 0x8000
 
             // Mirror if needed
-            if cartridge!.prgMemory.count == 0x4000 {
+            if self.cartridge.prgMemory.count == 0x4000 {
                 memoryIndex = memoryIndex % 0x4000
             }
 
-            return cartridge!.prgMemory[Int(memoryIndex)]
+            return self.cartridge.prgMemory[Int(memoryIndex)]
         default:
             print("Attempted to read cartridge at address: \(address)")
             return 0x00
@@ -34,7 +34,7 @@ struct Cnrom: Mapper {
             break
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_0011
-            self.cartridge!.chrBankIndex = Int(bankIndex)
+            self.cartridge.chrBankIndex = Int(bankIndex)
         default:
             print("Attempted to write to NROM cartridge at address: \(address)")
         }

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -1,0 +1,169 @@
+//
+//  Mmc1.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 10/29/24.
+//
+
+struct Mmc1: Mapper {
+    public var cartridge: Cartridge
+
+    private var prgRomBankMode: Int = 0
+    private var chrRomBankMode: Int = 0
+    private var prgBank: UInt8 = 0
+    private var chrBank0: UInt8 = 0
+    private var chrBank1: UInt8 = 0
+    private var prgOffsets: [Int] = [Int](repeating: 0, count: 2)
+    private var chrOffsets: [Int] = [Int](repeating: 0, count: 2)
+    private var shiftRegister: UInt8 = 0x10
+    private var controlRegister: UInt8 = 0x00
+
+    init(cartridge: Cartridge) {
+        self.cartridge = cartridge
+        self.prgOffsets[1] = self.prgBankOffset(index: -1)
+    }
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let bank = Int(address / 0x1000)
+            let bankOffset = Int(address % 0x1000)
+            let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
+            return self.cartridge.chrMemory[memoryIndex]
+        case 0x8000 ... 0xFFFF:
+            let addressOffset = address - 0x8000
+            let bank = Int(addressOffset / 0x4000)
+            let bankOffset = Int(addressOffset % 0x4000)
+            let memoryIndex = Int(self.prgOffsets[bank]) + bankOffset
+            return self.cartridge.prgMemory[memoryIndex]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    mutating public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let bank = Int(address / 0x1000)
+            let bankOffset = Int(address % 0x1000)
+            let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
+            self.cartridge.chrMemory[memoryIndex] = byte
+        case 0x8000 ... 0xFFFF:
+            self.updateRegisters(address: address, byte: byte)
+        default:
+            print("Attempted to write to cartridge at address: \(address)")
+        }
+    }
+
+    mutating private func updateRegisters(address: UInt16, byte: UInt8) {
+        if byte & 0x80 == 0x80 {
+            self.shiftRegister = 0x10
+            self.updateControlRegister(byte: self.controlRegister | 0x0C)
+            self.updateOffsets()
+        } else {
+            let writeComplete = (self.shiftRegister & 0x01) == 0x01
+            self.shiftRegister >>= 1
+            self.shiftRegister |= ((byte & 0x01) << 4)
+
+            if writeComplete {
+                self.updateOtherThings(address: address, byte: self.shiftRegister)
+                self.shiftRegister = 0x10
+                self.updateOffsets()
+            }
+        }
+    }
+
+    mutating private func updateOtherThings(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x9FFF:
+            self.updateControlRegister(byte: byte)
+        case 0xA000 ... 0xBFFF:
+            self.chrBank0 = byte
+        case 0xC000 ... 0xDFFF:
+            self.chrBank1 = byte
+        default:
+            self.prgBank = byte & 0x0F
+        }
+    }
+
+    mutating private func updateControlRegister(byte: UInt8) {
+        self.controlRegister = byte
+
+        let mirroringBits = self.controlRegister & 0b0000_0011
+        switch mirroringBits {
+        case 0:
+            self.cartridge.mirroring = .singleScreen0
+        case 1:
+            self.cartridge.mirroring = .singleScreen1
+        case 2:
+            self.cartridge.mirroring = .vertical
+        case 3:
+            self.cartridge.mirroring = .horizontal
+        default:
+            break
+        }
+
+        self.prgRomBankMode = Int((self.controlRegister & 0b0000_1100) >> 2)
+        self.chrRomBankMode = Int((self.controlRegister & 0b0001_0000) >> 4)
+    }
+
+    mutating private func updateOffsets() {
+        switch self.prgRomBankMode {
+        case 0, 1:
+            self.prgOffsets[0] = self.prgBankOffset(index: Int(self.prgBank & 0xFE))
+            self.prgOffsets[1] = self.prgBankOffset(index: Int(self.prgBank | 0x01))
+        case 2:
+            self.prgOffsets[0] = 0
+            self.prgOffsets[1] = self.prgBankOffset(index: Int(self.prgBank))
+        case 3:
+            self.prgOffsets[0] = self.prgBankOffset(index: Int(self.prgBank))
+            self.prgOffsets[1] = self.prgBankOffset(index: -1)
+        default:
+            break
+        }
+
+        switch self.chrRomBankMode {
+        case 0:
+            self.chrOffsets[0] = self.chrBankOffset(index: Int(self.chrBank0 & 0xFE))
+            self.chrOffsets[1] = self.chrBankOffset(index: Int(self.chrBank0 | 0x01))
+        case 1:
+            self.chrOffsets[0] = self.chrBankOffset(index: Int(self.chrBank0))
+            self.chrOffsets[1] = self.chrBankOffset(index: Int(self.chrBank1))
+        default:
+            break
+        }
+    }
+
+    private func prgBankOffset(index: Int) -> Int {
+        var copyIndex = index
+        if copyIndex >= 0x80 {
+            copyIndex -= 0x100
+        }
+
+        copyIndex %= self.cartridge.prgMemory.count / 0x4000
+
+        var offset = copyIndex * 0x4000
+        if offset < 0 {
+            offset += self.cartridge.prgMemory.count
+        }
+
+        return offset
+    }
+
+    private func chrBankOffset(index: Int) -> Int {
+        var copyIndex = index
+        if copyIndex >= 0x80 {
+            copyIndex -= 0x100
+        }
+
+        copyIndex %= self.cartridge.chrMemory.count / 0x1000
+
+        var offset = copyIndex * 0x1000
+        if offset < 0 {
+            offset += self.cartridge.chrMemory.count
+        }
+
+        return offset
+    }
+}

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -6,22 +6,22 @@
 //
 
 struct Nrom: Mapper {
-    public var cartridge: Cartridge? = nil
+    public var cartridge: Cartridge
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
-            return cartridge!.chrMemory[memoryIndex]
+            return self.cartridge.chrMemory[memoryIndex]
         case 0x8000 ... 0xFFFF:
             var memoryIndex = address - 0x8000
 
             // Mirror if needed
-            if cartridge!.prgMemory.count == 0x4000 {
+            if self.cartridge.prgMemory.count == 0x4000 {
                 memoryIndex = memoryIndex % 0x4000
             }
 
-            return cartridge!.prgMemory[Int(memoryIndex)]
+            return self.cartridge.prgMemory[Int(memoryIndex)]
         default:
             print("Attempted to read cartridge at address: \(address)")
             return 0x00

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -6,20 +6,20 @@
 //
 
 struct Uxrom: Mapper {
-    public var cartridge: Cartridge? = nil
+    public var cartridge: Cartridge
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
-            return cartridge!.chrMemory[memoryIndex]
+            return self.cartridge.chrMemory[memoryIndex]
         case 0x8000 ... 0xBFFF:
-            let memoryIndex = cartridge!.prgBankIndex * 0x4000 + Int(address - 0x8000)
-            return cartridge!.prgMemory[Int(memoryIndex)]
+            let memoryIndex = self.cartridge.prgBankIndex * 0x4000 + Int(address - 0x8000)
+            return self.cartridge.prgMemory[Int(memoryIndex)]
         case 0xC000 ... 0xFFFF:
             let lastBankStart = 7 * 0x4000
             let memoryIndex = lastBankStart + Int(address - 0xC000)
-            return cartridge!.prgMemory[Int(memoryIndex)]
+            return self.cartridge.prgMemory[Int(memoryIndex)]
         default:
             print("Attempted to read cartridge at address: \(address)")
             return 0x00
@@ -30,10 +30,10 @@ struct Uxrom: Mapper {
         switch address {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
-            cartridge!.chrMemory[memoryIndex] = byte
+            self.cartridge.chrMemory[memoryIndex] = byte
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_1111
-            cartridge!.prgBankIndex = Int(bankIndex)
+            self.cartridge.prgBankIndex = Int(bankIndex)
         default:
             print("Attempted to write to NROM cartridge at address: \(address)")
         }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -47,8 +47,6 @@ import SwiftUI
         let data: Data = try Data(contentsOf: fileUrl)
         let romBytes = [UInt8](data)
         let cartridge = try Cartridge(bytes: romBytes)
-        let mapper = cartridge.mapperNumber.makeMapper(cartridge: cartridge)
-        cartridge.mapper = mapper
 
         self.cpu.loadCartridge(cartridge: cartridge)
         self.cartridgeLoaded = true

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -47,6 +47,8 @@ import SwiftUI
         let data: Data = try Data(contentsOf: fileUrl)
         let romBytes = [UInt8](data)
         let cartridge = try Cartridge(bytes: romBytes)
+        let mapper = cartridge.mapperNumber.makeMapper(cartridge: cartridge)
+        cartridge.mapper = mapper
 
         self.cpu.loadCartridge(cartridge: cartridge)
         self.cartridgeLoaded = true


### PR DESCRIPTION
This PR introduces a new MMC1 mapper that opens up the emulator to a slew of other games. It is a significantly more complex one than the others implemented up to this point, and it was largely based on the one in Michael Fogleman's emulator, https://github.com/fogleman/nes/blob/master/nes/mapper1.go. The following changes were made:

* Because this mapper needs to mutate state in its constructor _and_ have a reference back to `Cartridge`, at least for the MMC1 mapper, the initialization process needed to be modified across the board for all mappers, not just this one. The `Cartridge` initializer now sets a `mapperNumber` field first and has a `lazy var` property for the relevant `Mapper`, which will only materialize when it is needed via the call to `MapperNumber.makeMapper()` which now takes a `Cartridge` reference.
* The `Mapper` protocol now demands that the `writeByte()` method be desiganted as `mutating` since the MMC1 mapper indeed manages and mutates a significant amount of internal state in that method.
* Now that each mapper has a hard reference to `Cartridge`, there is no need for force unwraps in any of their own methods.

It should be noted that Shy Shark does not render completely properly, and the issue is captured here https://github.com/quephird/happiNESs/issues/63. Nonetheless, games with the mapper are largely playable.