### PR TITLE
Support NES 2.0 ROMs

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		87C5B3292CD9C3C9008580A6 /* Mmc1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3242CD9C3C9008580A6 /* Mmc1.swift */; };
 		87C5B32A2CD9C3C9008580A6 /* Uxrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3252CD9C3C9008580A6 /* Uxrom.swift */; };
 		87C5B32B2CD9C3C9008580A6 /* Nrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3262CD9C3C9008580A6 /* Nrom.swift */; };
+		87C5B32E2CDD71D9008580A6 /* TimingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B32D2CDD71D9008580A6 /* TimingMode.swift */; };
 		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
 		87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* MapperNumber.swift */; };
 		87E981472CD076660090A200 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981462CD076660090A200 /* Mapper.swift */; };
@@ -169,6 +170,7 @@
 		87C5B3242CD9C3C9008580A6 /* Mmc1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mmc1.swift; sourceTree = "<group>"; };
 		87C5B3252CD9C3C9008580A6 /* Uxrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Uxrom.swift; sourceTree = "<group>"; };
 		87C5B3262CD9C3C9008580A6 /* Nrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nrom.swift; sourceTree = "<group>"; };
+		87C5B32D2CDD71D9008580A6 /* TimingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingMode.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
 		87D265162C9DECAF00C143B1 /* MapperNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapperNumber.swift; sourceTree = "<group>"; };
 		87E981462CD076660090A200 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				874F51AA2CBF036600B12037 /* RegisterBit.swift */,
 				874F51B02CC03F1500B12037 /* RegisterBitMask.swift */,
 				8744B1922C1D6D59001B44B5 /* StatusRegister.swift */,
+				87C5B32D2CDD71D9008580A6 /* TimingMode.swift */,
 				8763D06D2C3A340C006C1B4F /* Tracing.swift */,
 				871F62332C6541D300132962 /* UInt16+bytes.swift */,
 				87D265142C9146F400C143B1 /* ViewPort.swift */,
@@ -532,6 +535,7 @@
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,
 				87E981472CD076660090A200 /* Mapper.swift in Sources */,
 				874F51AB2CBF036600B12037 /* RegisterBit.swift in Sources */,
+				87C5B32E2CDD71D9008580A6 /* TimingMode.swift in Sources */,
 				870AABE42CB382E000E9F3B6 /* CPU+execution.swift in Sources */,
 				87184D052C7028F10003D090 /* PPUStatusRegister.swift in Sources */,
 				870AABE02CB37EA000E9F3B6 /* CPU+instructions.swift in Sources */,

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -10,6 +10,7 @@ public class Cartridge {
     static let prgMemoryPageSize: Int = 16384
     static let chrMemoryPageSize: Int = 8192
 
+    public var timingMode: TimingMode
     public var mirroring: Mirroring
     public var mapperNumber: MapperNumber
     public var prgMemory: [UInt8]
@@ -29,6 +30,15 @@ public class Cartridge {
             throw NESError.versionTwoPointOhOrEarlierSupported
         }
         let isNesTwoPointOh = inesVersion == 2
+
+        let timingMode = if isNesTwoPointOh {
+            TimingMode(rawValue: bytes[9] & 0b0000_0001)
+        } else {
+            TimingMode(rawValue: bytes[12] & 0b0000_0011)
+        }
+        guard let timingMode, [.ntsc, .pal].contains(timingMode) else {
+            throw NESError.unsupportedTimingMode
+        }
 
         let fourScreenBit = bytes[6] & 0b1000 != 0;
         let horizontalVerticalbit = bytes[6] & 0b1 != 0;
@@ -95,6 +105,7 @@ public class Cartridge {
             Array(bytes[chrMemoryStart ..< (chrMemoryStart + chrRomSize)])
         }
 
+        self.timingMode = timingMode
         self.mirroring = mirroring
         self.prgMemory = prgMemory
         self.prgBankIndex = 0

--- a/happiNESs/MapperNumber.swift
+++ b/happiNESs/MapperNumber.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 9/20/24.
 //
 
-public enum MapperNumber: UInt8 {
+public enum MapperNumber: UInt16 {
     case nrom = 0
     case mmc1 = 1
     case uxrom = 2

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -19,6 +19,10 @@ struct Nrom: Mapper {
             // Mirror if needed
             if self.cartridge.prgMemory.count == 0x4000 {
                 memoryIndex = memoryIndex % 0x4000
+            } else if self.cartridge.prgMemory.count == 0x2000 {
+                // ACHTUNG! This is a hack for games like Galaxian which are one
+                // of the very vew games that has an 8Kb PRG ROM
+                memoryIndex = memoryIndex % 0x2000
             }
 
             return self.cartridge.prgMemory[Int(memoryIndex)]

--- a/happiNESs/NESError.swift
+++ b/happiNESs/NESError.swift
@@ -11,7 +11,7 @@ enum NESError: Equatable, Error, LocalizedError {
     case romFileCouldNotBeSelected
     case romFileCouldNotBeOpened
     case romNotInInesFormat
-    case versionTwoPointOhNotSupported
+    case versionTwoPointOhOrEarlierSupported
     case mapperNotSupported(Int)
 
     var errorDescription: String? {
@@ -22,8 +22,8 @@ enum NESError: Equatable, Error, LocalizedError {
             "Unable to open file"
         case .romNotInInesFormat:
             "ROM file not in iNES format"
-        case .versionTwoPointOhNotSupported:
-            "NES 2.0 ROMs not yet supported"
+        case .versionTwoPointOhOrEarlierSupported:
+            "NES 2.0 ROMs or earlier supported only"
         case .mapperNotSupported(let mapperNumber):
             String(format: "Mapper number %03d not supported", mapperNumber)
         }

--- a/happiNESs/NESError.swift
+++ b/happiNESs/NESError.swift
@@ -12,6 +12,7 @@ enum NESError: Equatable, Error, LocalizedError {
     case romFileCouldNotBeOpened
     case romNotInInesFormat
     case versionTwoPointOhOrEarlierSupported
+    case unsupportedTimingMode
     case mapperNotSupported(Int)
 
     var errorDescription: String? {
@@ -24,6 +25,8 @@ enum NESError: Equatable, Error, LocalizedError {
             "ROM file not in iNES format"
         case .versionTwoPointOhOrEarlierSupported:
             "NES 2.0 ROMs or earlier supported only"
+        case .unsupportedTimingMode:
+            "Only NTSC and PAL ROMs currently supported"
         case .mapperNotSupported(let mapperNumber):
             String(format: "Mapper number %03d not supported", mapperNumber)
         }

--- a/happiNESs/TimingMode.swift
+++ b/happiNESs/TimingMode.swift
@@ -1,0 +1,13 @@
+//
+//  TimingMode.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/7/24.
+//
+
+public enum TimingMode: UInt8 {
+    case ntsc = 0
+    case pal = 1
+    case multipleRegion = 2
+    case dendy = 3
+}


### PR DESCRIPTION
So, this PR is a fairly robust first cut at supporting NES 2.0 ROM files, while support for earlier versions remains. For now, I don't parse the part of the header that specifies sizes for PRG RAM or CHR RAM since I haven't yet implemented any mappers which utilize either. 

Some notable changes:

* The initializer for `Cartridge` parses out PRG ROM and CHR ROM sizes correctly for both NES 2.0 ROMs as well as earlier versions. The parsing of the mapper number is also parsed correctly for both versions of ROM files.
* The timing mode is also parsed for both ROM versions, and for now, only ROMs that are explicitly designated to be in NTSC or PAL format are supported.
* This includes a small hack to handle ROMs using mapper 000 and have only 8K PRG ROM.
