### PR TITLE
Make fullscreenable while disallowing resizability

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can also specify the scale of the screen between 1x, 2x, and 3x through the 
 
 <img src="./images/set_scale.png" />
 
+... or through hitting ⌘-1, ⌘-2, or ⌘-3, respectively. Alternately, if you are on macOS 15.1 or later, you can run the game in fullscreen mode by selecting the "Enter Full Screen" choice from the View menu or via hitting the 🌐-F chord.
+
 Hitting ⌘-R within happiNESs at any time while playing a game will reset it.
 
 # Supported games
@@ -41,16 +43,27 @@ So far, the following mappers and associated games have been tested in this emul
   - 1941
   - Donkey Kong
   - Galaga
+  - Galaxian
   - Ms. Pacman
   - Pacman
   - Super Mario Bros.
   - Xevious
+- 001
+  - Castlevania II
+  - Double Dribble
+  - Pinball Quest
 - 002
   - 1943
+  - Blades of Steel
   - Castlevania
 - 003
   - Gradius
+  - Gyruss
   - Tiger Heli
+- 007
+  - Sky Shark (HUD is jumpy)
+  - Marble Madness (text box glitches a little at start of level)
+  - Wheel of Fortune
 
 Also, this emulator now supports sound! Games should play and sound _pretty_ close to the original, however certain things like timings and IRQ interrupt handling may not be quite right and will need some work to correct.
 

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 @Observable @MainActor class Console {
     static let frameRate = 60
+    static let defaultScale = 2.0
 
     public static let keyMappings: [KeyEquivalent : JoypadButton] = [
         .upArrow : .up,
@@ -33,7 +34,7 @@ import SwiftUI
     // pixels has changed, namely any of the elements of  `screenBuffer`.
     @ObservationIgnored private var cpu: CPU
     var screenBuffer: [UInt8] = PPU.makeEmptyScreenBuffer()
-    var scale: Double = 2.0
+    var scale: Double = Console.defaultScale
 
     internal init() throws {
         let bus = Bus()

--- a/happiNESsApp/ContentView.swift
+++ b/happiNESsApp/ContentView.swift
@@ -28,7 +28,6 @@ struct ContentView: View {
             if self.console.cartridgeLoaded {
                 Screen(screenBuffer: console.screenBuffer,
                        scale: console.scale)
-                .padding()
                 .focusable()
                 .focusEffectDisabled()
                 .focused($focused)
@@ -42,10 +41,7 @@ struct ContentView: View {
                 Image("happiNESs")
             }
         }
-        .frame(
-            maxWidth: CGFloat(Screen.width) * console.scale,
-            maxHeight: CGFloat(Screen.height) * console.scale)
-        .fixedSize()
+        .scaledToFit()
     }
 }
 

--- a/happiNESsApp/happiNESsApp.swift
+++ b/happiNESsApp/happiNESsApp.swift
@@ -116,9 +116,15 @@ struct happiNESsApp: App {
                 .keyboardShortcut("r", modifiers: .command)
                 .disabled(!console.cartridgeLoaded)
                 Picker(selection: $console.scale, label: Text("Scale")) {
-                    Text("1x").tag(1.0)
-                    Text("2x").tag(2.0)
-                    Text("3x").tag(3.0)
+                    Text("1x")
+                        .tag(1.0)
+                        .keyboardShortcut("1", modifiers: .command)
+                    Text("2x")
+                        .tag(2.0)
+                        .keyboardShortcut("2", modifiers: .command)
+                    Text("3x")
+                        .tag(3.0)
+                        .keyboardShortcut("3", modifiers: .command)
                 }
                 .disabled(isFullscreen)
             }

--- a/happiNESsApp/happiNESsApp.swift
+++ b/happiNESsApp/happiNESsApp.swift
@@ -34,6 +34,11 @@ struct happiNESsApp: App {
     }
 
     var body: some Scene {
+        let commonView = ContentView()
+            .environment(console)
+            .alert(errorMessage, isPresented: $showAlert, actions: {})
+            .dialogSeverity(.critical)
+
         Window("happiNESs", id: "main") {
             if #available(macOS 15.0, *) {
                 HStack {
@@ -43,7 +48,7 @@ struct happiNESsApp: App {
                         // ContentView actually works.
                         Spacer(minLength: NSScreen.main!.frame.width/2.0)
                     }
-                    ContentView()
+                    commonView
                     if isFullscreen {
                         Spacer(minLength: NSScreen.main!.frame.width/2.0)
                     }
@@ -51,9 +56,6 @@ struct happiNESsApp: App {
                     .background(Color.black)
                     .windowFullScreenBehavior(.enabled)
                     .windowResizeBehavior(.disabled)
-                    .environment(console)
-                    .alert(errorMessage, isPresented: $showAlert, actions: {})
-                    .dialogSeverity(.critical)
                     .onReceive(Self.fullscreenNotificationPublisher) { notification in
                         switch notification.name {
                         case NSWindow.didEnterFullScreenNotification:
@@ -71,10 +73,7 @@ struct happiNESsApp: App {
                         }
                     }
             } else {
-                ContentView()
-                    .environment(console)
-                    .alert(errorMessage, isPresented: $showAlert, actions: {})
-                    .dialogSeverity(.critical)
+                commonView
             }
         }
         .windowResizability(.contentSize)

--- a/happiNESsApp/happiNESsApp.swift
+++ b/happiNESsApp/happiNESsApp.swift
@@ -38,11 +38,14 @@ struct happiNESsApp: App {
             if #available(macOS 15.0, *) {
                 HStack {
                     if isFullscreen {
-                        Spacer(minLength: 500)
+                        // NOTA BENE: We need to set the minimum lenght of the spacer
+                        // here to something large enough so that the centering of the
+                        // ContentView actually works.
+                        Spacer(minLength: NSScreen.main!.frame.width/2.0)
                     }
                     ContentView()
                     if isFullscreen {
-                        Spacer(minLength: 500)
+                        Spacer(minLength: NSScreen.main!.frame.width/2.0)
                     }
                 }
                     .background(Color.black)


### PR DESCRIPTION
This PR introduces fullscreen mode for happiNESs. However, you need to be on macOS 15.1 or later in order to be able to do this, and so it was critical that the emulator continued to run in windowed mode without regression, which it does. Some crucial points to make:

* Getting this to work was _really_ tricky. There may be other clearer ways but in order to be able to capture when the window entered or exited fullscreen mode, and then be able to set compute the proper scaling accordingly, I needed to add the `onReceive()` modifier on the topmost view in the window, and capture events from a static `NotificationCenter.Publisher` configured to send those events. Inside the closure for the modifier, the computer's window height is captured, and the new scale computed from it.
* The closure above also captures the original scaling factor from when it was originally in windowed mode, and restores it upon exiting fullscreen mode.
* It was _extremely_ difficult getting the `ContentView` centered within the window in fullscreen mode. Using default `Spacer`s within an `HStack` weren't sufficient; the `minLength`s had to be large enough for it to work but I didn't want to hardcode any one magic number. And so, I chose to compute the half width of the main screen and use that as the `minLength` parameter for each `Spacer` and that worked.
* The app window remains unresizable in windowed mode.
* There are now keyboard bindings to the scaling actions, namely, ⌘-1, ⌘-2, or ⌘-3.
* Scaling is disabled when in fullscreen mode for obvious reasons; this is done by inspecting the state of the `isFullscreen` var which is set and reset in the `onReceive()` closure described above.