### PR TITLE
OMFG I FIXED SKY SHARK

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ So far, the following mappers and associated games have been tested in this emul
   - Gyruss
   - Tiger Heli
 - 007
-  - Sky Shark (HUD is jumpy)
+  - Sky Shark
   - Marble Madness (text box glitches a little at start of level)
   - Wheel of Fortune
 

--- a/happiNESs/Address.swift
+++ b/happiNESs/Address.swift
@@ -29,6 +29,7 @@ enum AddressBitMask: Address {
     case coarseY    = 0b0000_0011_1110_0000
     case coarseX    = 0b0000_0000_0001_1111
 
+    case bit14      = 0b0100_0000_0000_0000
     case highByte   = 0b0011_1111_0000_0000
     case lowByte    = 0b0000_0000_1111_1111
 

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -37,6 +37,13 @@ extension PPU {
 
     mutating public func updateAddress(byte: UInt8) {
         if !self.wRegister {
+            // ACHTUNG! Per the following excerpt in the NESDev wiki for PPUADDR, we
+            // need to _explicitly_ reset bit 14 here:
+            //
+            //     "However, bit 14 of the internal t register that holds the data written
+            //     to PPUADDR is forced to 0 when writing the PPUADDR high byte"
+            //
+            //     https://www.nesdev.org/wiki/PPU_registers#PPUADDR_-_VRAM_address_($2006_write)
             self.nextSharedAddress[.highByte] = byte
             self.nextSharedAddress[.bit14] = 0
         } else {

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -38,6 +38,7 @@ extension PPU {
     mutating public func updateAddress(byte: UInt8) {
         if !self.wRegister {
             self.nextSharedAddress[.highByte] = byte
+            self.nextSharedAddress[.bit14] = 0
         } else {
             self.nextSharedAddress[.lowByte] = byte
             self.currentSharedAddress = self.nextSharedAddress

--- a/happiNESs/PPU+caching.swift
+++ b/happiNESs/PPU+caching.swift
@@ -328,7 +328,7 @@ extension PPU {
             // Reset coarse X
             self.currentSharedAddress[.coarseX] = 0b0_0000
             // Toggle horizontal nametable
-            self.currentSharedAddress[.nametable] ^= 0b01
+            self.currentSharedAddress[.nametableX] ^= 0b1
         } else {
             // Just increment coarse X
             self.currentSharedAddress[.coarseX] += 0b0_0001
@@ -344,7 +344,7 @@ extension PPU {
                 // Reset coarse Y
                 self.currentSharedAddress[.coarseY] = 0b0_0000
                 // Toggle vertical nametable
-                self.currentSharedAddress[.nametable] ^= 0b10
+                self.currentSharedAddress[.nametableY] ^= 0b1
             } else if self.currentSharedAddress[.coarseY] == 0b1_1111 {
                 // ACHTUNG! How would we ever get to this branch?
                 //

--- a/happiNESs/PPU+caching.swift
+++ b/happiNESs/PPU+caching.swift
@@ -195,7 +195,7 @@ extension PPU {
     }
 
     private func getSpriteData(for oamIndex: Int) -> UInt32 {
-        let tileY = Int(self.oamRegister.data[oamIndex]) + 1
+        let tileY = Int(self.oamRegister.data[oamIndex])
         let attributeByte = self.oamRegister.data[oamIndex + 2]
 
         let flipVertical = ((attributeByte >> 7) & 1) == 1
@@ -285,7 +285,7 @@ extension PPU {
             // ACHTUNG! Note that the value in OAM is one less than the actual Y value!
             //
             //    https://www.nesdev.org/wiki/PPU_OAM#Byte_0
-            let tileY = Int(self.oamRegister.data[oamIndex]) + 1
+            let tileY = Int(self.oamRegister.data[oamIndex])
 
             let spritePixelY = self.scanline - tileY
             // The sprite height property takes into account whether or not all

--- a/happiNESs/PPU+rendering.swift
+++ b/happiNESs/PPU+rendering.swift
@@ -20,6 +20,10 @@ extension PPU {
     }
 
     private func getCurrentBackgroundTileColor() -> NESColor? {
+        if self.maskRegister[.showBackground] == false {
+            return nil
+        }
+
         let tileData = self.currentTileData
         let pixelData = tileData >> ((7 - self.currentFineX) * 4)
         let colorIndex = Int(pixelData & 0x0F)
@@ -27,6 +31,10 @@ extension PPU {
     }
 
     private func getCurrentSpriteColor() -> (color: NESColor, index: Int, backgroundPriority: Bool)? {
+        if self.maskRegister[.showSprites] == false {
+            return nil
+        }
+
         // Note that `currentSprites` is ordered from left to right by the OAM index,
         // with the first (zeroth) element being the so-called sprite zero. Furthermore,
         // the strategy here is to find the first sprite whose pixels intersect with the

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -123,6 +123,9 @@ public struct PPU {
     var isCopyHorizontalScrollCycle: Bool {
         self.cycles == Self.width + 1
     }
+    var isCacheSpritesCycle: Bool {
+        self.cycles == Self.width + 1
+    }
     var isCopyVerticalScrollCycle: Bool {
         self.cycles >= 280 && self.cycles <= 304
     }
@@ -161,7 +164,7 @@ public struct PPU {
             self.cacheBackgroundTiles()
 
             // TODO: Revisit this because sprites should be cached for the _next_ line
-            if self.isVisibleLine && self.cycles == 0 {
+            if self.isVisibleLine && self.isCacheSpritesCycle {
                 self.cacheSprites()
             }
         }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -118,10 +118,10 @@ public struct PPU {
         self.cycles >= 1 && self.cycles <= Self.width
     }
     var isIncrementVerticalScrollCycle: Bool {
-        self.cycles == Self.width + 1
+        self.cycles == Self.width
     }
     var isCopyHorizontalScrollCycle: Bool {
-        self.cycles == Self.width + 2
+        self.cycles == Self.width + 1
     }
     var isCopyVerticalScrollCycle: Bool {
         self.cycles >= 280 && self.cycles <= 304

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -242,7 +242,7 @@ public struct PPU {
             self.handleNmiState()
             self.handleRendering()
             self.handleCaching()
-            redrawScreen = redrawScreen || self.handleVerticalBlank()
+            redrawScreen = self.handleVerticalBlank() || redrawScreen
             self.handleFrameCounts()
         }
 

--- a/happiNESs/Register.swift
+++ b/happiNESs/Register.swift
@@ -13,6 +13,7 @@ extension Register {
             (self & (1 << flag.bitIndex)) > 0
         }
         set {
+            self &= ~(1 << flag.bitIndex)
             self |= (newValue ? 1 : 0) << flag.bitIndex
         }
     }

--- a/happiNESsApp/Speaker.swift
+++ b/happiNESsApp/Speaker.swift
@@ -42,7 +42,7 @@ struct Speaker {
         engine.attach(sourceNode)
         engine.connect(sourceNode, to: mainMixer, format: inputFormat)
         engine.connect(mainMixer, to: output, format: outputFormat)
-        mainMixer.outputVolume = 0.5
+        mainMixer.outputVolume = 1.0
 
         try engine.start()
     }


### PR DESCRIPTION
So, the main purpose of this PR was to address the problem of a jumpy HUD in Sky Shark. The problem was due to my overlooking the following subtle statement in the NESDev wiki (https://www.nesdev.org/wiki/PPU_registers#PPUADDR_-_VRAM_address_($2006_write)):

"However, bit 14 of the internal t register that holds the data written to PPUADDR is forced to 0 when writing the PPUADDR high byte"

The result of my not doing so was that fine scroll Y in the temporary VRAM address was not being properly managed, and was off by four by the time the HUD was drawn (and about when PPUADDR was being updated by the game). The fix was to introduce a new bitmask, `.bit14` in `AddressBitMask` and set the relevant bit to 0 when updating the high byte.

In the midst of this investigation, I also discovered a slew of other tiny but potentially significant bugs, including:

* A fix for when we increment Y scroll and copy X scroll; the PPU cycles at which we should be doing so were off by one.
* A fix for making sure we cache background tile for the _next_ line. The Y value in the OAM byte for a background tile is one less than where it actually is, and so we can don't need to add one to it as long as we cache the tile data on the previous scanline and in horizontal blank. And so we do so on cycle 257 on each line for the next. 
* A fix which addresses a very subtle potential boolean short-circuit error in the main loop in the PPU `tick()` function: previously if `redrawScreen` was already true, we'd neglect to call `handleVerticalBlank()`.
* Another fix ensuring that when sprites or background tiles are turned off, that we immediately return a nil color when fetching a color for a sprite or background tile, respectively.
* A fix in `Register` where previously we were not necessarily overwriting bits in `setBits()`.

Two other changes that were made that were more cosmetic than bug fixes:

* A volume adjustment for the APU mixer; the volume is now set to 1.0 instead of 0.5.
* Improve clarity by explicitly toggling namespace X or namespace Y bits when incrementing X and Y, respectively. This was done by using the more specific bitmasks in `AddressBitMask`, namely .`namespaceX` and `.namespaceY`.
