### PR TITLE
Fix popping noise during certain games

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		87E981532CD8B5990090A200 /* NMIDelayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981522CD8B5990090A200 /* NMIDelayState.swift */; };
 		87E981562CD9A6950090A200 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87E981552CD9A6950090A200 /* nestest.nes */; };
 		87E981582CD9A6BF0090A200 /* ppu_vbl_nmi.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87E981572CD9A6BF0090A200 /* ppu_vbl_nmi.nes */; };
+		87F234532CE8567F00D2FDA6 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F234522CE8567700D2FDA6 /* Filter.swift */; };
+		87F234562CE856DB00D2FDA6 /* LowPassFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F234552CE856D100D2FDA6 /* LowPassFilter.swift */; };
+		87F234582CE8574400D2FDA6 /* FilterChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F234572CE8573F00D2FDA6 /* FilterChain.swift */; };
+		87F2345A2CE85E0100D2FDA6 /* HighPassFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F234592CE85DFA00D2FDA6 /* HighPassFilter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -177,6 +181,10 @@
 		87E981522CD8B5990090A200 /* NMIDelayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMIDelayState.swift; sourceTree = "<group>"; };
 		87E981552CD9A6950090A200 /* nestest.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = nestest.nes; sourceTree = "<group>"; };
 		87E981572CD9A6BF0090A200 /* ppu_vbl_nmi.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = ppu_vbl_nmi.nes; sourceTree = "<group>"; };
+		87F234522CE8567700D2FDA6 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		87F234552CE856D100D2FDA6 /* LowPassFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowPassFilter.swift; sourceTree = "<group>"; };
+		87F234572CE8573F00D2FDA6 /* FilterChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChain.swift; sourceTree = "<group>"; };
+		87F234592CE85DFA00D2FDA6 /* HighPassFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighPassFilter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -278,6 +286,9 @@
 				870AABE32CB382E000E9F3B6 /* CPU+execution.swift */,
 				870AABDF2CB37EA000E9F3B6 /* CPU+instructions.swift */,
 				870AABE12CB381C100E9F3B6 /* CPU+memory.swift */,
+				87F234522CE8567700D2FDA6 /* Filter.swift */,
+				87F234572CE8573F00D2FDA6 /* FilterChain.swift */,
+				87F234542CE856C400D2FDA6 /* Filters */,
 				8771BFA72CCD62C500306E13 /* Interrupt.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
@@ -350,6 +361,15 @@
 				87E981552CD9A6950090A200 /* nestest.nes */,
 			);
 			path = roms;
+			sourceTree = "<group>";
+		};
+		87F234542CE856C400D2FDA6 /* Filters */ = {
+			isa = PBXGroup;
+			children = (
+				87F234552CE856D100D2FDA6 /* LowPassFilter.swift */,
+				87F234592CE85DFA00D2FDA6 /* HighPassFilter.swift */,
+			);
+			path = Filters;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -513,6 +533,7 @@
 			files = (
 				8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */,
 				870AABDC2CB3533700E9F3B6 /* PPU+IO.swift in Sources */,
+				87F234582CE8574400D2FDA6 /* FilterChain.swift in Sources */,
 				870AABDE2CB36D4100E9F3B6 /* PPU+rendering.swift in Sources */,
 				870AABE22CB381C100E9F3B6 /* CPU+memory.swift in Sources */,
 				871F62302C62FE9E00132962 /* PPU.swift in Sources */,
@@ -534,6 +555,7 @@
 				8744B1932C1D6D59001B44B5 /* StatusRegister.swift in Sources */,
 				8744B18D2C1CB9F4001B44B5 /* AddressingMode.swift in Sources */,
 				87E981472CD076660090A200 /* Mapper.swift in Sources */,
+				87F234562CE856DB00D2FDA6 /* LowPassFilter.swift in Sources */,
 				874F51AB2CBF036600B12037 /* RegisterBit.swift in Sources */,
 				87C5B32E2CDD71D9008580A6 /* TimingMode.swift in Sources */,
 				870AABE42CB382E000E9F3B6 /* CPU+execution.swift in Sources */,
@@ -541,6 +563,7 @@
 				870AABE02CB37EA000E9F3B6 /* CPU+instructions.swift in Sources */,
 				8771BFA82CCD62C500306E13 /* Interrupt.swift in Sources */,
 				87184D0E2C756BEB0003D090 /* OAMRegister.swift in Sources */,
+				87F2345A2CE85E0100D2FDA6 /* HighPassFilter.swift in Sources */,
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
 				87184D0A2C7511F90003D090 /* MaskRegister.swift in Sources */,
@@ -553,6 +576,7 @@
 				877E970B2C7E4716007513B5 /* Joypad.swift in Sources */,
 				87C5B3282CD9C3C9008580A6 /* Cnrom.swift in Sources */,
 				870AABD82CB32FAA00E9F3B6 /* PPU+caching.swift in Sources */,
+				87F234532CE8567F00D2FDA6 /* Filter.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
 				874F51B12CC03F1500B12037 /* RegisterBitMask.swift in Sources */,
 				874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */,

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -126,7 +126,7 @@ extension APU {
     }
 
     mutating public func updateStatus(byte: UInt8) {
-        self.status = byte
+        self.status = byte[.apuStatus]
 
         self.pulse1.enabled = self.status[.pulse1Enabled]
         self.pulse2.enabled = self.status[.pulse2Enabled]

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -297,7 +297,7 @@ extension APU {
                               noise: noiseSample,
                               dmc: dmcSample)
 
-        let filteredSignalValue = self.filterChain.filter(signalValue: signalValue)
+        let filteredSignalValue = self.filterChain.filter(inputValue: signalValue)
         self.buffer.append(value: filteredSignalValue)
     }
 

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -11,6 +11,7 @@ enum SequencerMode {
 }
 
 public struct APU {
+    static let audioSampleRate: Float = 44100.0
     static let frameCounterRate = CPU.frequency / 240.0
 
     // Values for this table taken from:
@@ -25,7 +26,7 @@ public struct APU {
     public var cycles: Int = 0
     private var sequencerMode: SequencerMode = .four
     private var frameIrqInhibited: Bool = false
-    public var sampleRate: Double
+    public var sampleRate: Float
 
     public var pulse1: PulseChannel = PulseChannel(channelNumber: .one)
     public var pulse2: PulseChannel = PulseChannel(channelNumber: .two)
@@ -37,11 +38,11 @@ public struct APU {
     public var status: Register = 0x00
     public var buffer = AudioRingBuffer()
 
-    public init(sampleRate: Double) {
+    public init(sampleRate: Float) {
         self.sampleRate = sampleRate
         self.filterChain = FilterChain(filters: [
-            HighPassFilter(sampleRate: 44100.0, cutoffFrequency: 90),
-            LowPassFilter(sampleRate: 44100.0, cutoffFrequency: 14000),
+            HighPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 90),
+            LowPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 14000),
         ])
     }
 
@@ -165,8 +166,8 @@ extension APU {
 
 extension APU {
     var shouldSendSample: Bool {
-        let oldSampleNumber = Int(Double(self.cycles - 1) / self.sampleRate)
-        let newSampleNumber = Int(Double(self.cycles) / self.sampleRate)
+        let oldSampleNumber = Int(Float(self.cycles - 1) / self.sampleRate)
+        let newSampleNumber = Int(Float(self.cycles) / self.sampleRate)
         return newSampleNumber != oldSampleNumber
     }
 

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -27,7 +27,6 @@ public struct APU {
     private var frameIrqInhibited: Bool = false
     public var sampleRate: Double
 
-    // TODO: Add the other channels
     public var pulse1: PulseChannel = PulseChannel(channelNumber: .one)
     public var pulse2: PulseChannel = PulseChannel(channelNumber: .two)
     public var triangle: TriangleChannel = TriangleChannel()
@@ -249,7 +248,6 @@ extension APU {
     }
 
     mutating private func stepEnvelope() {
-        // TODO: call the methods on the other channels once they're implemented
         self.pulse1.stepEnvelope()
         self.pulse2.stepEnvelope()
         self.triangle.stepCounter()
@@ -257,13 +255,11 @@ extension APU {
     }
 
     mutating private func stepSweep() {
-        // TODO: call the methods on the other channels once they're implemented
         self.pulse1.stepSweep()
         self.pulse2.stepSweep()
     }
 
     mutating private func stepLength() {
-        // TODO: call the methods on the other channels once they're implemented
         self.pulse1.stepLength()
         self.pulse2.stepLength()
         self.triangle.stepLength()

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -11,7 +11,7 @@ enum SequencerMode {
 }
 
 public struct APU {
-    static let audioSampleRate: Float = 44100.0
+    public static let audioSampleRate: Float = 44100.0
     static let frameCounterRate = CPU.frequency / 240.0
 
     // Values for this table taken from:

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -41,6 +41,12 @@ public struct APU {
 
     public init(sampleRate: Float) {
         self.sampleRate = sampleRate
+        // NOTA BENE: Even though according to the following section in the NESDev
+        // wiki that there ought to be two high pass filters, I found that adding
+        // the one for 400 Hz made the resultant audio sound way too tinny, and so
+        // only one high pass and one low pass have been left in.
+        //
+        //     https://www.nesdev.org/wiki/APU_Mixer
         self.filterChain = FilterChain(filters: [
             HighPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 90),
             LowPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 14000),

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -169,6 +169,10 @@ extension APU {
 
 extension APU {
     var shouldSendSample: Bool {
+        // NOTA BENE: We can't just use simple modulo arithmetic here
+        // because we're dealing with Floats and Doubles and need to avoid
+        // truncation errors. For the time being, this is the most
+        // reliable way to detect if and when to send a sample.
         let oldSampleNumber = Int(Float(self.cycles - 1) / self.sampleRate)
         let newSampleNumber = Int(Float(self.cycles) / self.sampleRate)
         return newSampleNumber != oldSampleNumber

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -21,7 +21,7 @@ public class Bus {
     public init() {
         self.ppu = PPU()
         // TODO: Need to explain this!!!
-        self.apu = APU(sampleRate: CPU.frequency / 44100.0)
+        self.apu = APU(sampleRate: Float(CPU.frequency) / APU.audioSampleRate)
 
         self.vram = [UInt8](repeating: 0x00, count: 2048)
         self.joypad = Joypad()

--- a/happiNESs/Channels/DMCChannel.swift
+++ b/happiNESs/Channels/DMCChannel.swift
@@ -91,8 +91,7 @@ extension DMCChannel {
 
     mutating private func stepReader() {
         if self.currentLength > 0 && self.bitCount == 0 {
-            // TODO: Figure out how best to do this
-            // self.cpu.stall += 4
+            self.bus!.cpu!.stall += 4
 
             self.shiftRegister = self.bus!.readByte(address: self.currentAddress)
             self.bitCount = 8

--- a/happiNESs/Filter.swift
+++ b/happiNESs/Filter.swift
@@ -9,17 +9,17 @@ public protocol Filter {
     var b0: Float { get set }
     var b1: Float { get set }
     var a1: Float { get set }
-    var prevX: Float { get set }
-    var prevY: Float { get set }
+    var prevInputValue: Float { get set }
+    var prevOutputValue: Float { get set }
 
     mutating func filter(signalValue: Float) -> Float
 }
 
 extension Filter {
     mutating public func filter(signalValue: Float) -> Float {
-        let outputValue = self.b0*signalValue + self.b1*self.prevX - self.a1*self.prevY
-        self.prevY = outputValue
-        self.prevX = signalValue
+        let outputValue = self.b0*signalValue + self.b1*self.prevInputValue - self.a1*self.prevOutputValue
+        self.prevOutputValue = outputValue
+        self.prevInputValue = signalValue
         return outputValue
     }
 }

--- a/happiNESs/Filter.swift
+++ b/happiNESs/Filter.swift
@@ -1,0 +1,25 @@
+//
+//  Filter.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/15/24.
+//
+
+public protocol Filter {
+    var b0: Float { get set }
+    var b1: Float { get set }
+    var a1: Float { get set }
+    var prevX: Float { get set }
+    var prevY: Float { get set }
+
+    mutating func filter(signalValue: Float) -> Float
+}
+
+extension Filter {
+    mutating public func filter(signalValue: Float) -> Float {
+        let outputValue = self.b0*signalValue + self.b1*self.prevX - self.a1*self.prevY
+        self.prevY = outputValue
+        self.prevX = signalValue
+        return outputValue
+    }
+}

--- a/happiNESs/Filter.swift
+++ b/happiNESs/Filter.swift
@@ -12,14 +12,14 @@ public protocol Filter {
     var prevInputValue: Float { get set }
     var prevOutputValue: Float { get set }
 
-    mutating func filter(signalValue: Float) -> Float
+    mutating func filter(inputValue: Float) -> Float
 }
 
 extension Filter {
-    mutating public func filter(signalValue: Float) -> Float {
-        let outputValue = self.b0*signalValue + self.b1*self.prevInputValue - self.a1*self.prevOutputValue
+    mutating public func filter(inputValue: Float) -> Float {
+        let outputValue = self.b0*inputValue + self.b1*self.prevInputValue - self.a1*self.prevOutputValue
         self.prevOutputValue = outputValue
-        self.prevInputValue = signalValue
+        self.prevInputValue = inputValue
         return outputValue
     }
 }

--- a/happiNESs/Filter.swift
+++ b/happiNESs/Filter.swift
@@ -17,6 +17,21 @@ public protocol Filter {
 
 extension Filter {
     mutating public func filter(inputValue: Float) -> Float {
+        // NOTA BENE: This code was adapted from Michael Fogleman's implementation here:
+        //
+        //     https://github.com/fogleman/nes/blob/master/nes/filter.go#L19-L24
+        //
+        // I don't fully understand the theory behind how filters work but this is apparently
+        // an implementation of a so-called first order causal IIR difference equation, some
+        // of the details of which are explained here:
+        //
+        //     https://dsp.stackexchange.com/a/51710
+        //
+        // the "b" parameters are the so-called feedforward filter coefficients and the a1
+        // a1 value is a feedback filter coefficient. The general form of the equation is
+        // discussed here:
+        //
+        //     https://en.wikipedia.org/wiki/Infinite_impulse_response#Transfer_function_derivation
         let outputValue = self.b0*inputValue + self.b1*self.prevInputValue - self.a1*self.prevOutputValue
         self.prevOutputValue = outputValue
         self.prevInputValue = inputValue

--- a/happiNESs/FilterChain.swift
+++ b/happiNESs/FilterChain.swift
@@ -8,10 +8,10 @@
 public struct FilterChain {
     public var filters: [Filter]
 
-    mutating public func filter(signalValue: Float) -> Float {
-        var outputValue: Float = signalValue
+    mutating public func filter(inputValue: Float) -> Float {
+        var outputValue: Float = inputValue
         for i in filters.indices {
-            outputValue = filters[i].filter(signalValue: outputValue)
+            outputValue = filters[i].filter(inputValue: outputValue)
         }
 
         return outputValue

--- a/happiNESs/FilterChain.swift
+++ b/happiNESs/FilterChain.swift
@@ -1,0 +1,19 @@
+//
+//  FilterChain.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/15/24.
+//
+
+public struct FilterChain {
+    public var filters: [Filter]
+
+    mutating public func filter(signalValue: Float) -> Float {
+        var outputValue: Float = signalValue
+        for i in filters.indices {
+            outputValue = filters[i].filter(signalValue: outputValue)
+        }
+
+        return outputValue
+    }
+}

--- a/happiNESs/Filters/HighPassFilter.swift
+++ b/happiNESs/Filters/HighPassFilter.swift
@@ -13,12 +13,17 @@ public struct HighPassFilter: Filter {
     public var prevOutputValue: Float
 
     init(sampleRate: Float, cutoffFrequency: Float) {
+        // NOTA BENE: As with the low pass filter, I can hardly find any
+        // information on the derivation of the values for b0, b1, and a1.
+        // I _did_ find a few comments here basically saying that the high
+        // pass filter is effectively the additive inverse of the low pass
+        // filter for the "b" coefficients:
+        //
+        //     https://www.reddit.com/r/DSP/comments/1dw854e/comment/lbtewn3/
         let c = sampleRate / Float.pi / cutoffFrequency
-        let a0i = 1 / (1 + c)
-
-        self.b0 = c * a0i
-        self.b1 = -c * a0i
-        self.a1 = (1 - c) * a0i
+        self.b0 = c / (1 + c)
+        self.b1 = -c / (1 + c)
+        self.a1 = (1 - c) / (1 + c)
         self.prevInputValue = 0.0
         self.prevOutputValue = 0.0
     }

--- a/happiNESs/Filters/HighPassFilter.swift
+++ b/happiNESs/Filters/HighPassFilter.swift
@@ -1,0 +1,25 @@
+//
+//  HighPassFilter.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/15/24.
+//
+
+public struct HighPassFilter: Filter {
+    public var b0: Float
+    public var b1: Float
+    public var a1: Float
+    public var prevX: Float
+    public var prevY: Float
+
+    init(sampleRate: Double, cutoffFrequency: Double) {
+        let c = Float(sampleRate) / Float.pi / Float(cutoffFrequency)
+        let a0i = 1 / (1 + c)
+
+        self.b0 = c * a0i
+        self.b1 = -c * a0i
+        self.a1 = (1 - c) * a0i
+        self.prevX = 0.0
+        self.prevY = 0.0
+    }
+}

--- a/happiNESs/Filters/HighPassFilter.swift
+++ b/happiNESs/Filters/HighPassFilter.swift
@@ -9,17 +9,17 @@ public struct HighPassFilter: Filter {
     public var b0: Float
     public var b1: Float
     public var a1: Float
-    public var prevX: Float
-    public var prevY: Float
+    public var prevInputValue: Float
+    public var prevOutputValue: Float
 
-    init(sampleRate: Double, cutoffFrequency: Double) {
-        let c = Float(sampleRate) / Float.pi / Float(cutoffFrequency)
+    init(sampleRate: Float, cutoffFrequency: Float) {
+        let c = sampleRate / Float.pi / cutoffFrequency
         let a0i = 1 / (1 + c)
 
         self.b0 = c * a0i
         self.b1 = -c * a0i
         self.a1 = (1 - c) * a0i
-        self.prevX = 0.0
-        self.prevY = 0.0
+        self.prevInputValue = 0.0
+        self.prevOutputValue = 0.0
     }
 }

--- a/happiNESs/Filters/LowPassFilter.swift
+++ b/happiNESs/Filters/LowPassFilter.swift
@@ -9,17 +9,17 @@ public struct LowPassFilter: Filter {
     public var b0: Float
     public var b1: Float
     public var a1: Float
-    public var prevX: Float
-    public var prevY: Float
+    public var prevInputValue: Float
+    public var prevOutputValue: Float
 
-    init(sampleRate: Double, cutoffFrequency: Double) {
-        let c = Float(sampleRate) / Float.pi / Float(cutoffFrequency)
+    init(sampleRate: Float, cutoffFrequency: Float) {
+        let c = sampleRate / Float.pi / cutoffFrequency
         let a0i = 1 / (1 + c)
 
         self.b0 = a0i
         self.b1 = a0i
         self.a1 = (1 - c) * a0i
-        self.prevX = 0.0
-        self.prevY = 0.0
+        self.prevInputValue = 0.0
+        self.prevOutputValue = 0.0
     }
 }

--- a/happiNESs/Filters/LowPassFilter.swift
+++ b/happiNESs/Filters/LowPassFilter.swift
@@ -1,0 +1,25 @@
+//
+//  LowPassFilter.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/15/24.
+//
+
+public struct LowPassFilter: Filter {
+    public var b0: Float
+    public var b1: Float
+    public var a1: Float
+    public var prevX: Float
+    public var prevY: Float
+
+    init(sampleRate: Double, cutoffFrequency: Double) {
+        let c = Float(sampleRate) / Float.pi / Float(cutoffFrequency)
+        let a0i = 1 / (1 + c)
+
+        self.b0 = a0i
+        self.b1 = a0i
+        self.a1 = (1 - c) * a0i
+        self.prevX = 0.0
+        self.prevY = 0.0
+    }
+}

--- a/happiNESs/Filters/LowPassFilter.swift
+++ b/happiNESs/Filters/LowPassFilter.swift
@@ -13,12 +13,17 @@ public struct LowPassFilter: Filter {
     public var prevOutputValue: Float
 
     init(sampleRate: Float, cutoffFrequency: Float) {
+        // NOTA BENE: I can find _very_ little information on the thinking behind
+        // the assignment of values to b0, b1, and a1. The most I can find is later
+        // on in this StackExchange answer for their _relative_ values:
+        //
+        //     https://dsp.stackexchange.com/a/51714
+        //
+        // As for the _specific_ values, I still cannot find anything... but it does work.
         let c = sampleRate / Float.pi / cutoffFrequency
-        let a0i = 1 / (1 + c)
-
-        self.b0 = a0i
-        self.b1 = a0i
-        self.a1 = (1 - c) * a0i
+        self.b0 = 1 / (1 + c)
+        self.b1 = 1 / (1 + c)
+        self.a1 = (1 - c) / (1 + c)
         self.prevInputValue = 0.0
         self.prevOutputValue = 0.0
     }

--- a/happiNESsApp/Speaker.swift
+++ b/happiNESsApp/Speaker.swift
@@ -24,11 +24,19 @@ struct Speaker {
                                         channels: 1,
                                         interleaved: outputFormat.isInterleaved)
 
+        var cachedBufferValue: Float = 0.0
         let sourceNode = AVAudioSourceNode { [inputBuffer] _, _, frameCount, audioBufferList -> OSStatus in
             let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
 
             for frame in 0..<Int(frameCount) {
-                let value = inputBuffer.take() ?? 0.0
+                // NOTA BENE: Because the emulated timing between the CPU and APU
+                // is not quite accurate, the buffer is sometimes empty, and so
+                // if we put a zero value into the output buffer, the result is a
+                // popping/slapping sound. So for now, we cache the previous value
+                // of the sample and use that in the event that the buffer, resulting
+                // in a much smoother audio output.
+                let value = inputBuffer.take() ?? cachedBufferValue
+                cachedBufferValue = value
 
                 for outputAudioBuffer in ablPointer {
                     let outputBuffer: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(outputAudioBuffer)


### PR DESCRIPTION
This PR primarily addresses a small but _very_ annoying problem with happiNESs, namely that certain games, especiallly Dr. Mario and Castlevania II, produce a rhythmic popping noise. Ultimately, this is due to the CPU running just fast enough that the APU's buffer runs out of sample values to supply to the audio engine. When this happens, the APU buffer returns a value of 0.0, which results in a the popping noise because it's a drastic departure from the previous nonzero value. The fix, for now, is to cache the previous non-zero value, which yields no discontinuities. The ultimate solution would be to somehow get the timing correct between the CPU and the production of samples for the buffer, but this will do for now.

Other tiny fixes and adjustments in this PR:

* The implementation of low pass and high pass filters. Originally, I had thought that these would stifle the popping noise but alas they do not do so. I kept them in because the actual NES had them, albeit realized in hardware not software.
* The DMC channel now correctly stalls the CPU for four cycles.
* Several superfluous TODO comments were removed.
* The main audio sample rate, 44.1 kHz, is now a static constant in the APU.
* `stepSequencer()` now manages a `sequenceCount` property and switches over slightly different values to more closely align with the timing of an actual NES APU sequencer.
* `updateStatus()` now only takes the lowest five bits of the inbound byte value. There was no bug relevant to this but this makes it clear what the behavior is intended to be.