### PR TITLE
Get "The Legend of Zelda" working

### DIFF
--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -58,7 +58,7 @@ extension Bus {
             return self.apu.readByte(address: address)
         case 0x4016:
             return self.joypad.readByteWithoutMutating()
-        case 0x8000 ... 0xFFFF:
+        case 0x6000 ... 0xFFFF:
             return self.cartridge!.readByte(address: address)
         default:
             return 0x00
@@ -100,7 +100,7 @@ extension Bus {
             self.apu.writeByte(address: address, byte: byte)
         case 0x4016:
             self.joypad.writeByte(byte: byte)
-        case 0x8000 ... 0xFFFF:
+        case 0x6000 ... 0xFFFF:
             self.cartridge!.writeByte(address: address, byte: byte)
         default:
             break

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -17,6 +17,7 @@ public class Cartridge {
     public var prgBankIndex: Int
     public var chrMemory: [UInt8]
     public var chrBankIndex: Int
+    public var sram: [UInt8]
 
     public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self)
 
@@ -111,6 +112,7 @@ public class Cartridge {
         self.prgBankIndex = 0
         self.chrMemory = chrMemory
         self.chrBankIndex = 0
+        self.sram = [UInt8](repeating: 0x00, count: 0x2000)
     }
 
     public func readByte(address: UInt16) -> UInt8 {

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -13,6 +13,9 @@ struct Axrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
             return cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
         case 0x8000 ... 0xFFFF:
             let memoryIndex = cartridge.prgBankIndex * 0x8000 + Int(address - 0x8000)
             return cartridge.prgMemory[Int(memoryIndex)]
@@ -27,6 +30,9 @@ struct Axrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
             cartridge.chrMemory[memoryIndex] = byte
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_0111
             cartridge.prgBankIndex = Int(bankIndex)

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -13,6 +13,9 @@ struct Cnrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = self.cartridge.chrBankIndex * 0x2000 + Int(address)
             return self.cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
         case 0x8000 ... 0xFFFF:
             var memoryIndex = address - 0x8000
 
@@ -32,6 +35,9 @@ struct Cnrom: Mapper {
         switch address {
         case 0x0000 ... 0x1FFF:
             break
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_0011
             self.cartridge.chrBankIndex = Int(bankIndex)

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -30,6 +30,9 @@ struct Mmc1: Mapper {
             let bankOffset = Int(address % 0x1000)
             let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
             return self.cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
         case 0x8000 ... 0xFFFF:
             let addressOffset = address - 0x8000
             let bank = Int(addressOffset / 0x4000)
@@ -49,6 +52,9 @@ struct Mmc1: Mapper {
             let bankOffset = Int(address % 0x1000)
             let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
             self.cartridge.chrMemory[memoryIndex] = byte
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
         case 0x8000 ... 0xFFFF:
             self.updateRegisters(address: address, byte: byte)
         default:

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -13,6 +13,9 @@ struct Nrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
             return self.cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
         case 0x8000 ... 0xFFFF:
             var memoryIndex = address - 0x8000
 
@@ -37,6 +40,9 @@ struct Nrom: Mapper {
         switch address {
         case 0x0000 ... 0x1FFF:
             break
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
         case 0x8000 ... 0xFFFF:
             break
         default:

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -13,6 +13,9 @@ struct Uxrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
             return self.cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
         case 0x8000 ... 0xBFFF:
             let memoryIndex = self.cartridge.prgBankIndex * 0x4000 + Int(address - 0x8000)
             return self.cartridge.prgMemory[Int(memoryIndex)]
@@ -31,6 +34,9 @@ struct Uxrom: Mapper {
         case 0x0000 ... 0x1FFF:
             let memoryIndex = Int(address)
             self.cartridge.chrMemory[memoryIndex] = byte
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
         case 0x8000 ... 0xFFFF:
             let bankIndex = byte & 0b0000_1111
             self.cartridge.prgBankIndex = Int(bankIndex)

--- a/happiNESsTests/CPUTests.swift
+++ b/happiNESsTests/CPUTests.swift
@@ -364,7 +364,7 @@ final class CPUTests: XCTestCase {
 
         XCTAssertEqual(cpu.readByte(address: 0x01FD), 0x86)
         XCTAssertEqual(cpu.readByte(address: 0x01FC), 0x04)
-        XCTAssertEqual(cpu.readByte(address: 0x01FB), 0b0010_1101)
+        XCTAssertEqual(cpu.readByte(address: 0x01FB), 0b0011_1101)
         XCTAssertEqual(cpu.programCounter, 0x0000)
     }
 

--- a/happiNESsTests/RomTests.swift
+++ b/happiNESsTests/RomTests.swift
@@ -28,14 +28,14 @@ final class RomTests: XCTestCase {
     func testRomWithBadVersion() throws {
         let header: [UInt8] = [
             0x4E, 0x45, 0x53, 0x1A,
-            0x02, 0x01, 0x31, 0b0000_1000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02, 0x01, 0x31, 0b0000_1100, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ]
         let programBytes: [UInt8] = [0xA9, 0x42]
         let prgRomBytes = Array(repeating: 0x00, count: 0x0600) + programBytes + Array(repeating: 0x00, count: 0x9400 - programBytes.count)
         let chrRomBytes = [UInt8](repeating: 0x00, count: 8192)
         let romBytes = header + prgRomBytes + chrRomBytes
 
-        let expectedError = NESError.versionTwoPointOhNotSupported
+        let expectedError = NESError.versionTwoPointOhOrEarlierSupported
         XCTAssertThrowsError(try Cartridge(bytes: romBytes)) { actualError in
             XCTAssertEqual(actualError as! NESError, expectedError)
         }


### PR DESCRIPTION
Originally, the moment I tried to start "The Legend of Zelda" the game would just hang. After some tracing and debugging, it turned out that the game program would eventually jump to address 0x6EE9, and happiNESs accessed memory for the opcode at that location, the then current implementation would simply return 0x00. And that is the BRK instruction, which subsequently caused the emulator to remain in a loop. 

The root cause was that I had forgotten to implement save RAM and a mapping configuration to read and write from it, and so the solution was to add that and "The Legend of Zelda" appears to run fine. The only annoyance is that there is no persistent save state and so you have to start all over each time you load the cartridge.

All included ROM test suites pass. Some extant unit tests needed updating due to changes in PRs prior to this one, but now all unit tests pass as well.
