### PR TITLE
Create mechanism to automatically and periodically save the state of SRAM if the underlying ROM has a battery

### DIFF
--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -14,7 +14,7 @@ public class Bus {
     public var cpu: CPU? = nil
     public var ppu: PPU
     public var apu: APU
-    var cartridge: Cartridge?
+    public var cartridge: Cartridge?
     var vram: [UInt8]
     var joypad: Joypad
 

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -26,7 +26,7 @@ public class Cartridge {
             throw NESError.romNotInInesFormat
         }
 
-        let inesVersion = (bytes[7] >> 2) & 0b11;
+        let inesVersion = (bytes[7] >> 2) & 0b11
         if inesVersion > 2 {
             throw NESError.versionTwoPointOhOrEarlierSupported
         }
@@ -41,8 +41,8 @@ public class Cartridge {
             throw NESError.unsupportedTimingMode
         }
 
-        let fourScreenBit = bytes[6] & 0b1000 != 0;
-        let horizontalVerticalbit = bytes[6] & 0b1 != 0;
+        let fourScreenBit = bytes[6] & 0b1000 != 0
+        let horizontalVerticalbit = bytes[6] & 0b1 != 0
         let mirroring: Mirroring = switch (fourScreenBit, horizontalVerticalbit) {
         case (true, _): .fourScreen
         case (false, true): .vertical

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -10,6 +10,7 @@ public class Cartridge {
     static let prgMemoryPageSize: Int = 16384
     static let chrMemoryPageSize: Int = 8192
 
+    public var hasBattery: Bool
     public var timingMode: TimingMode
     public var mirroring: Mirroring
     public var mapperNumber: MapperNumber
@@ -41,6 +42,7 @@ public class Cartridge {
             throw NESError.unsupportedTimingMode
         }
 
+        let hasBattery = (bytes[6] & 0b0000_0010) != 0
         let fourScreenBit = bytes[6] & 0b1000 != 0
         let horizontalVerticalbit = bytes[6] & 0b1 != 0
         let mirroring: Mirroring = switch (fourScreenBit, horizontalVerticalbit) {
@@ -106,6 +108,7 @@ public class Cartridge {
             Array(bytes[chrMemoryStart ..< (chrMemoryStart + chrRomSize)])
         }
 
+        self.hasBattery = hasBattery
         self.timingMode = timingMode
         self.mirroring = mirroring
         self.prgMemory = prgMemory

--- a/happiNESs/NESError.swift
+++ b/happiNESs/NESError.swift
@@ -14,6 +14,9 @@ enum NESError: Equatable, Error, LocalizedError {
     case versionTwoPointOhOrEarlierSupported
     case unsupportedTimingMode
     case mapperNotSupported(Int)
+    case cannotCreateSaveDataDirectory
+    case invalidSaveDatafile
+    case unableToSaveDataFile(String)
 
     var errorDescription: String? {
         switch self {
@@ -29,6 +32,12 @@ enum NESError: Equatable, Error, LocalizedError {
             "Only NTSC and PAL ROMs currently supported"
         case .mapperNotSupported(let mapperNumber):
             String(format: "Mapper number %03d not supported", mapperNumber)
+        case .cannotCreateSaveDataDirectory:
+            "Could not create save directory for game data files"
+        case .invalidSaveDatafile:
+            "Save data file is somehow invalid and cannot be loaded"
+        case .unableToSaveDataFile(let message):
+            "Error saving SRAM: \(message)"
         }
     }
 }

--- a/happiNESsApp/happiNESsApp.swift
+++ b/happiNESsApp/happiNESsApp.swift
@@ -38,6 +38,13 @@ struct happiNESsApp: App {
             .environment(console)
             .alert(errorMessage, isPresented: $showAlert, actions: {})
             .dialogSeverity(.critical)
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                do {
+                    try self.console.saveSram()
+                } catch {
+                    self.setErrorMessage(message: error.localizedDescription)
+                }
+            }
 
         Window("happiNESs", id: "main") {
             if #available(macOS 15.0, *) {
@@ -127,6 +134,11 @@ struct happiNESsApp: App {
                         .keyboardShortcut("3", modifiers: .command)
                 }
                 .disabled(isFullscreen)
+            }
+        }
+        .onChange(of: console.currentError) { oldValue, newValue in
+            if let consoleError = console.currentError {
+                self.setErrorMessage(message: consoleError.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
This PR does what it says on the tin and only for ROMs for which there is a battery detected in the header. Although not a large set of changes, they are subtle. They include the following functionality:

* Save files are saved to the local file system in the directory, `$USER/Library/Containers/happiNESsApp/Data/Library/Application Support/happiNES/`. If the directory structure cannot be created, an error is thrown.
* Save file names are derived from the name of the ROM file with the `.dat` extension. 
* The emulator will only save the SRAM if it has been written to within the most recent five seconds. This will hopefully be a right cadence that ensures that the save file doesn't miss anything but without overwhelming the file system.
* If there is a problem loading the current save file, the ROM will not load and the application will display an appropriate error dialog box.
* If there is any error encountered during saving, the application will also display an error dialog box.
* The emulator will also save the SRAM just before it terminates.
