### PR TITLE
Implement MMC3 mapper (004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ So far, the following mappers and associated games have been tested in this emul
   - Gradius
   - Gyruss
   - Tiger Heli
+- 004
+  - Astyanax
+  - Kirby's Adventure
+  - Rampart
 - 007
   - Sky Shark
   - Marble Madness (text box glitches a little at start of level)

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		871F62302C62FE9E00132962 /* PPU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F622F2C62FE9E00132962 /* PPU.swift */; };
 		871F62342C6541D300132962 /* UInt16+bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F62332C6541D300132962 /* UInt16+bytes.swift */; };
 		871F62362C65631F00132962 /* ControllerRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F62352C65631F00132962 /* ControllerRegister.swift */; };
+		87244E592CF925DB00EC26D3 /* Mmc3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87244E582CF925D700EC26D3 /* Mmc3.swift */; };
 		8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1762C1CB9B3001B44B5 /* happiNESs.docc */; };
 		8744B17D2C1CB9B3001B44B5 /* happiNESs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8744B1722C1CB9B3001B44B5 /* happiNESs.framework */; };
 		8744B1822C1CB9B3001B44B5 /* CPUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8744B1812C1CB9B3001B44B5 /* CPUTests.swift */; };
@@ -139,6 +140,7 @@
 		871F622F2C62FE9E00132962 /* PPU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPU.swift; sourceTree = "<group>"; };
 		871F62332C6541D300132962 /* UInt16+bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt16+bytes.swift"; sourceTree = "<group>"; };
 		871F62352C65631F00132962 /* ControllerRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControllerRegister.swift; sourceTree = "<group>"; };
+		87244E582CF925D700EC26D3 /* Mmc3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mmc3.swift; sourceTree = "<group>"; };
 		8744B1722C1CB9B3001B44B5 /* happiNESs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = happiNESs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8744B1752C1CB9B3001B44B5 /* happiNESs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = happiNESs.h; sourceTree = "<group>"; };
 		8744B1762C1CB9B3001B44B5 /* happiNESs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = happiNESs.docc; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 				87C5B3222CD9C3C9008580A6 /* Axrom.swift */,
 				87C5B3232CD9C3C9008580A6 /* Cnrom.swift */,
 				87C5B3242CD9C3C9008580A6 /* Mmc1.swift */,
+				87244E582CF925D700EC26D3 /* Mmc3.swift */,
 				87C5B3262CD9C3C9008580A6 /* Nrom.swift */,
 				87C5B3252CD9C3C9008580A6 /* Uxrom.swift */,
 			);
@@ -582,6 +585,7 @@
 				874F51B72CC1E7D800B12037 /* AudioRingBuffer.swift in Sources */,
 				874F51B52CC1D05D00B12037 /* PulseChannel.swift in Sources */,
 				87C5B3272CD9C3C9008580A6 /* Axrom.swift in Sources */,
+				87244E592CF925DB00EC26D3 /* Mmc3.swift in Sources */,
 				87C5B32A2CD9C3C9008580A6 /* Uxrom.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -26,7 +26,7 @@ public struct APU {
     public var cycles: Int = 0
     private var sequencerMode: SequencerMode = .four
     private var sequencerCount: Int = 0
-    private var frameIrqInhibited: Bool = false
+    private var frameIrqEnabled: Bool = false
     public var sampleRate: Float
 
     public var pulse1: PulseChannel = PulseChannel(channelNumber: .one)
@@ -163,7 +163,7 @@ extension APU {
 
     mutating public func updateSequencer(byte: UInt8) {
         self.sequencerMode = byte[.sequencerMode] ? .five : .four
-        self.frameIrqInhibited = byte[.frameIrqInhibited]
+        self.frameIrqEnabled = !byte[.frameIrqInhibited]
 
         if self.sequencerMode == .five {
             self.stepEnvelope()
@@ -327,6 +327,8 @@ extension APU {
     }
 
     mutating private func generateIRQ() {
-        self.bus!.triggerIrq()
+        if self.frameIrqEnabled {
+            self.bus!.triggerIrq()
+        }
     }
 }

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -184,16 +184,16 @@ extension APU {
         return newSampleNumber != oldSampleNumber
     }
 
-    mutating public func tick(cpuCycles: Int) {
-        for _ in 0 ..< cpuCycles {
-            self.cycles += 1
+    // This function needs executes its body of instructions once for every tick
+    // of the CPU, unlike for the PPU and mapper tick() functions.
+    mutating public func tick() {
+        self.cycles += 1
 
-            self.stepTimer()
-            self.stepSequencer()
+        self.stepTimer()
+        self.stepSequencer()
 
-            if self.shouldSendSample {
-                self.sendSample()
-            }
+        if self.shouldSendSample {
+            self.sendSample()
         }
     }
 

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -72,7 +72,6 @@ public class CPU {
         var shouldRedrawScreen: Bool = false
         for _ in 0 ..< cycles {
             shouldRedrawScreen = self.bus.ppu.tick() || shouldRedrawScreen
-            self.bus.cartridge!.mapper.tick()
             self.bus.apu.tick()
         }
 

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -69,9 +69,14 @@ public class CPU {
     public func tick(cycles: Int) -> Bool {
         self.cycles += cycles
 
-        self.bus.apu.tick(cpuCycles: cycles)
-        self.bus.cartridge!.mapper.tick(cpuCycles: cycles)
-        return self.bus.ppu.tick(cpuCycles: cycles)
+        var shouldRedrawScreen: Bool = false
+        for _ in 0 ..< cycles {
+            shouldRedrawScreen = self.bus.ppu.tick() || shouldRedrawScreen
+            self.bus.cartridge!.mapper.tick()
+            self.bus.apu.tick()
+        }
+
+        return shouldRedrawScreen
     }
 
 

--- a/happiNESs/CPU.swift
+++ b/happiNESs/CPU.swift
@@ -70,6 +70,7 @@ public class CPU {
         self.cycles += cycles
 
         self.bus.apu.tick(cpuCycles: cycles)
+        self.bus.cartridge!.mapper.tick(cpuCycles: cycles)
         return self.bus.ppu.tick(cpuCycles: cycles)
     }
 

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -12,6 +12,7 @@ public class Cartridge {
 
     public var cartridgeUrl: URL
     public var saveDataFilePath: URL
+    public var bus: Bus
     public var hasBattery: Bool
     public var timingMode: TimingMode
     public var mirroring: Mirroring
@@ -27,9 +28,11 @@ public class Cartridge {
         }
     }
 
-    public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self)
+    public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self, bus: self.bus)
 
-    public init(cartridgeUrl: URL, saveDataFileDirectory: URL) throws {
+    public init(cartridgeUrl: URL,
+                saveDataFileDirectory: URL,
+                bus: Bus) throws {
         let data: Data = try Data(contentsOf: cartridgeUrl)
         let bytes = [UInt8](data)
 
@@ -137,6 +140,7 @@ public class Cartridge {
         self.prgBankIndex = 0
         self.chrMemory = chrMemory
         self.chrBankIndex = 0
+        self.bus = bus
     }
 
     public func readByte(address: UInt16) -> UInt8 {

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -5,10 +5,10 @@
 //  Created by Danielle Kefford on 10/28/24.
 //
 
-public protocol Mapper {
+public protocol Mapper: AnyObject  {
     var cartridge: Cartridge { get }
 
     func readByte(address: UInt16) -> UInt8
-    mutating func writeByte(address: UInt16, byte: UInt8)
-    mutating func tick(ppu: borrowing PPU)
+    func writeByte(address: UInt16, byte: UInt8)
+    func tick(ppu: borrowing PPU)
 }

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -10,5 +10,5 @@ public protocol Mapper {
 
     func readByte(address: UInt16) -> UInt8
     mutating func writeByte(address: UInt16, byte: UInt8)
-    mutating func tick()
+    mutating func tick(ppu: borrowing PPU)
 }

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -10,5 +10,5 @@ public protocol Mapper {
 
     func readByte(address: UInt16) -> UInt8
     mutating func writeByte(address: UInt16, byte: UInt8)
-    mutating func tick(cpuCycles: Int)
+    mutating func tick()
 }

--- a/happiNESs/Mapper.swift
+++ b/happiNESs/Mapper.swift
@@ -10,4 +10,5 @@ public protocol Mapper {
 
     func readByte(address: UInt16) -> UInt8
     mutating func writeByte(address: UInt16, byte: UInt8)
+    mutating func tick(cpuCycles: Int)
 }

--- a/happiNESs/MapperNumber.swift
+++ b/happiNESs/MapperNumber.swift
@@ -10,9 +10,10 @@ public enum MapperNumber: UInt16 {
     case mmc1 = 1
     case uxrom = 2
     case cnrom = 3
+    case mmc3 = 4
     case axrom = 7
 
-    public func makeMapper(cartridge: Cartridge) -> Mapper {
+    public func makeMapper(cartridge: Cartridge, bus: Bus) -> Mapper {
         switch self {
         case .nrom:
             return Nrom(cartridge: cartridge)
@@ -22,6 +23,8 @@ public enum MapperNumber: UInt16 {
             return Uxrom(cartridge: cartridge)
         case .cnrom:
             return Cnrom(cartridge: cartridge)
+        case .mmc3:
+            return Mmc3(cartridge: cartridge, bus: bus)
         case .axrom:
             return Axrom(cartridge: cartridge)
         }

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -44,7 +44,7 @@ struct Axrom: Mapper {
         }
     }
 
-    mutating func tick() {
+    mutating func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -44,7 +44,7 @@ struct Axrom: Mapper {
         }
     }
 
-    mutating func tick(cpuCycles: Int) {
+    mutating func tick() {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -5,8 +5,12 @@
 //  Created by Danielle Kefford on 10/28/24.
 //
 
-struct Axrom: Mapper {
+class Axrom: Mapper {
     public unowned var cartridge: Cartridge
+
+    init(cartridge: Cartridge) {
+        self.cartridge = cartridge
+    }
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
@@ -44,7 +48,7 @@ struct Axrom: Mapper {
         }
     }
 
-    mutating func tick(ppu: borrowing PPU) {
+    func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Axrom.swift
+++ b/happiNESs/Mappers/Axrom.swift
@@ -43,4 +43,8 @@ struct Axrom: Mapper {
             print("Attempted to write to NROM cartridge at address: \(address)")
         }
     }
+
+    mutating func tick(cpuCycles: Int) {
+        // No-op for this mapper type
+    }
 }

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -5,8 +5,12 @@
 //  Created by Danielle Kefford on 10/28/24.
 //
 
-struct Cnrom: Mapper {
+class Cnrom: Mapper {
     public unowned var cartridge: Cartridge
+
+    init(cartridge: Cartridge) {
+        self.cartridge = cartridge
+    }
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
@@ -46,7 +50,7 @@ struct Cnrom: Mapper {
         }
     }
 
-    mutating func tick(ppu: borrowing PPU) {
+    func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -46,7 +46,7 @@ struct Cnrom: Mapper {
         }
     }
 
-    mutating func tick(cpuCycles: Int) {
+    mutating func tick() {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -45,4 +45,8 @@ struct Cnrom: Mapper {
             print("Attempted to write to NROM cartridge at address: \(address)")
         }
     }
+
+    mutating func tick(cpuCycles: Int) {
+        // No-op for this mapper type
+    }
 }

--- a/happiNESs/Mappers/Cnrom.swift
+++ b/happiNESs/Mappers/Cnrom.swift
@@ -46,7 +46,7 @@ struct Cnrom: Mapper {
         }
     }
 
-    mutating func tick() {
+    mutating func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 10/29/24.
 //
 
-struct Mmc1: Mapper {
+class Mmc1: Mapper {
     public unowned var cartridge: Cartridge
 
     private var prgRomBankMode: Int = 0
@@ -45,7 +45,7 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating public func writeByte(address: UInt16, byte: UInt8) {
+    public func writeByte(address: UInt16, byte: UInt8) {
         switch address {
         case 0x0000 ... 0x1FFF:
             let bank = Int(address / 0x1000)
@@ -62,11 +62,11 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating func tick(ppu: borrowing PPU) {
+    func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 
-    mutating private func updateRegisters(address: UInt16, byte: UInt8) {
+    private func updateRegisters(address: UInt16, byte: UInt8) {
         if byte & 0x80 == 0x80 {
             self.shiftRegister = 0x10
             self.updateControlRegister(byte: self.controlRegister | 0x0C)
@@ -84,7 +84,7 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating private func updateOtherThings(address: UInt16, byte: UInt8) {
+    private func updateOtherThings(address: UInt16, byte: UInt8) {
         switch address {
         case 0x0000 ... 0x9FFF:
             self.updateControlRegister(byte: byte)
@@ -97,7 +97,7 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating private func updateControlRegister(byte: UInt8) {
+    private func updateControlRegister(byte: UInt8) {
         self.controlRegister = byte
 
         let mirroringBits = self.controlRegister & 0b0000_0011
@@ -118,7 +118,7 @@ struct Mmc1: Mapper {
         self.chrRomBankMode = Int((self.controlRegister & 0b0001_0000) >> 4)
     }
 
-    mutating private func updateOffsets() {
+    private func updateOffsets() {
         switch self.prgRomBankMode {
         case 0, 1:
             self.prgOffsets[0] = self.prgBankOffset(index: Int(self.prgBank & 0xFE))

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -62,6 +62,10 @@ struct Mmc1: Mapper {
         }
     }
 
+    mutating func tick(cpuCycles: Int) {
+        // No-op for this mapper type
+    }
+
     mutating private func updateRegisters(address: UInt16, byte: UInt8) {
         if byte & 0x80 == 0x80 {
             self.shiftRegister = 0x10

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -62,7 +62,7 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating func tick() {
+    mutating func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 

--- a/happiNESs/Mappers/Mmc1.swift
+++ b/happiNESs/Mappers/Mmc1.swift
@@ -62,7 +62,7 @@ struct Mmc1: Mapper {
         }
     }
 
-    mutating func tick(cpuCycles: Int) {
+    mutating func tick() {
         // No-op for this mapper type
     }
 

--- a/happiNESs/Mappers/Mmc3.swift
+++ b/happiNESs/Mappers/Mmc3.swift
@@ -51,10 +51,12 @@ struct Mmc3: Mapper {
         }
     }
 
-    mutating public func tick(cpuCycles: Int) {
+    // As with the PPU.tick() function, this one needs to execute the sequence
+    // of instructions three times for every tick of the CPU.
+    mutating public func tick() {
         let ppu = self.bus.ppu
 
-        for _ in 0 ..< cpuCycles * 3 {
+        for _ in 0 ..< 3 {
             if ppu.cycles != 280 {
                 return
             }

--- a/happiNESs/Mappers/Mmc3.swift
+++ b/happiNESs/Mappers/Mmc3.swift
@@ -1,0 +1,251 @@
+//
+//  Mmc3.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 11/28/24.
+//
+
+struct Mmc3: Mapper {
+    public unowned var cartridge: Cartridge
+
+    private var bus: Bus
+    private var prgRomBankMode: UInt8 = 0
+    private var chrRomBankMode: UInt8 = 0
+    private var registerIndex: Int = 0
+    private var registers: [UInt8] = [UInt8](repeating: 0x00, count: 8)
+    private var prgOffsets: [Int] = [Int](repeating: 0, count: 4)
+    private var chrOffsets: [Int] = [Int](repeating: 0, count: 8)
+    private var irqCounter: UInt8 = 0
+    private var irqCounterReload: UInt8 = 0
+    private var irqEnabled: Bool = false
+
+    init(cartridge: Cartridge, bus: Bus) {
+        self.cartridge = cartridge
+        self.bus = bus
+
+        self.prgOffsets[0] = self.prgBankOffset(index: 0)
+        self.prgOffsets[1] = self.prgBankOffset(index: 1)
+        self.prgOffsets[2] = self.prgBankOffset(index: -2)
+        self.prgOffsets[3] = self.prgBankOffset(index: -1)
+    }
+
+    public func readByte(address: UInt16) -> UInt8 {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let bank = Int(address / 0x0400)
+            let bankOffset = Int(address % 0x0400)
+            let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
+            return self.cartridge.chrMemory[memoryIndex]
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            return self.cartridge.sram[index]
+        case 0x8000 ... 0xFFFF:
+            let addressOffset = address - 0x8000
+            let bank = Int(addressOffset / 0x2000)
+            let bankOffset = Int(addressOffset % 0x2000)
+            let memoryIndex = Int(self.prgOffsets[bank]) + bankOffset
+            return self.cartridge.prgMemory[memoryIndex]
+        default:
+            print("Attempted to read cartridge at address: \(address)")
+            return 0x00
+        }
+    }
+
+    mutating public func tick(cpuCycles: Int) {
+        let ppu = self.bus.ppu
+
+        for _ in 0 ..< cpuCycles * 3 {
+            if ppu.cycles != 280 {
+                return
+            }
+
+            if ppu.scanline > 239 && ppu.scanline < 261 {
+                return
+            }
+
+            if !ppu.maskRegister[.showBackground] && !ppu.maskRegister[.showSprites] {
+                return
+            }
+
+            self.handleScanLine()
+        }
+    }
+
+    mutating private func handleScanLine() {
+        if self.irqCounter == 0 {
+            self.irqCounter = self.irqCounterReload
+        } else {
+            self.irqCounter -= 1
+
+            if self.irqCounter == 0 && self.irqEnabled {
+                self.bus.triggerIrq()
+            }
+        }
+    }
+
+    mutating public func writeByte(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x1FFF:
+            let bank = Int(address / 0x0400)
+            let bankOffset = Int(address % 0x0400)
+            let memoryIndex = Int(self.chrOffsets[bank]) + bankOffset
+            self.cartridge.chrMemory[memoryIndex] = byte
+        case 0x6000 ... 0x7FFF:
+            let index = Int(address - 0x6000)
+            self.cartridge.sram[index] = byte
+        case 0x8000 ... 0xFFFF:
+            self.writeRegister(address: address, byte: byte)
+        default:
+            print("Attempted to write to cartridge at address: \(address)")
+        }
+    }
+
+    mutating private func writeRegister(address: UInt16, byte: UInt8) {
+        switch address {
+        case 0x0000 ... 0x9FFF:
+            switch address%2 == 0 {
+            case true:
+                self.writeBankSelect(byte: byte)
+            case false:
+                self.writeBankData(byte: byte)
+            }
+        case 0xA000 ... 0xBFFF:
+            switch address%2 == 0 {
+            case true:
+                self.writeMirror(byte: byte)
+            case false:
+                self.writeProtect(byte: byte)
+            }
+        case 0xC000 ... 0xDFFF:
+            switch address%2 == 0 {
+            case true:
+                self.writeIrqLatch(byte: byte)
+            case false:
+                self.writeIrqReload(byte: byte)
+            }
+        default:
+            switch address%2 == 0 {
+            case true:
+                self.writeIrqDisable(byte: byte)
+            case false:
+                self.writeIrqEnable(byte: byte)
+            }
+        }
+    }
+
+
+    mutating private func writeBankData(byte: UInt8) {
+        self.registers[self.registerIndex] = byte
+        self.updateOffsets()
+    }
+
+    mutating private func writeBankSelect(byte: UInt8) {
+        self.prgRomBankMode = (byte >> 6) & 1
+        self.chrRomBankMode = (byte >> 7) & 1
+        self.registerIndex = Int(byte & 7)
+        self.updateOffsets()
+    }
+
+    mutating private func writeProtect(byte: UInt8) {
+        // No-op
+    }
+
+    mutating private func writeMirror(byte: UInt8) {
+        switch byte & 1 {
+        case 0:
+            self.cartridge.mirroring = .vertical
+        default:
+            self.cartridge.mirroring = .horizontal
+        }
+    }
+
+    mutating private func writeIrqReload(byte: UInt8) {
+        self.irqCounter = 0
+    }
+
+    mutating private func writeIrqLatch(byte: UInt8) {
+        self.irqCounterReload = byte
+    }
+
+    mutating private func writeIrqEnable(byte: UInt8) {
+        // Note that the input is ignored
+        self.irqEnabled = true
+    }
+
+    mutating private func writeIrqDisable(byte: UInt8) {
+        // Note that the input is ignored
+        self.irqEnabled = false
+    }
+
+    private func prgBankOffset(index: Int) -> Int {
+        var copyIndex = index
+        if copyIndex >= 0x80 {
+            copyIndex -= 0x100
+        }
+
+        copyIndex %= self.cartridge.prgMemory.count / 0x2000
+
+        var offset = copyIndex * 0x2000
+        if offset < 0 {
+            offset += self.cartridge.prgMemory.count
+        }
+
+        return offset
+    }
+
+    private func chrBankOffset(index: Int) -> Int {
+        var copyIndex = index
+        if copyIndex >= 0x80 {
+            copyIndex -= 0x100
+        }
+
+        copyIndex %= self.cartridge.chrMemory.count / 0x0400
+
+        var offset = copyIndex * 0x0400
+        if offset < 0 {
+            offset += self.cartridge.chrMemory.count
+        }
+
+        return offset
+    }
+
+    mutating private func updateOffsets() {
+        switch self.prgRomBankMode {
+        case 0:
+            self.prgOffsets[0] = self.prgBankOffset(index: Int(self.registers[6]))
+            self.prgOffsets[1] = self.prgBankOffset(index: Int(self.registers[7]))
+            self.prgOffsets[2] = self.prgBankOffset(index: -2)
+            self.prgOffsets[3] = self.prgBankOffset(index: -1)
+        case 1:
+            self.prgOffsets[0] = self.prgBankOffset(index: -2)
+            self.prgOffsets[1] = self.prgBankOffset(index: Int(self.registers[7]))
+            self.prgOffsets[2] = self.prgBankOffset(index: Int(self.registers[6]))
+            self.prgOffsets[3] = self.prgBankOffset(index: -1)
+        default:
+            break
+        }
+
+        switch self.chrRomBankMode {
+        case 0:
+            self.chrOffsets[0] = self.chrBankOffset(index: Int(self.registers[0] & 0xFE))
+            self.chrOffsets[1] = self.chrBankOffset(index: Int(self.registers[0] | 0x01))
+            self.chrOffsets[2] = self.chrBankOffset(index: Int(self.registers[1] & 0xFE))
+            self.chrOffsets[3] = self.chrBankOffset(index: Int(self.registers[1] | 0x01))
+            self.chrOffsets[4] = self.chrBankOffset(index: Int(self.registers[2]))
+            self.chrOffsets[5] = self.chrBankOffset(index: Int(self.registers[3]))
+            self.chrOffsets[6] = self.chrBankOffset(index: Int(self.registers[4]))
+            self.chrOffsets[7] = self.chrBankOffset(index: Int(self.registers[5]))
+        case 1:
+            self.chrOffsets[0] = self.chrBankOffset(index: Int(self.registers[2]))
+            self.chrOffsets[1] = self.chrBankOffset(index: Int(self.registers[3]))
+            self.chrOffsets[2] = self.chrBankOffset(index: Int(self.registers[4]))
+            self.chrOffsets[3] = self.chrBankOffset(index: Int(self.registers[5]))
+            self.chrOffsets[4] = self.chrBankOffset(index: Int(self.registers[0] & 0xFE))
+            self.chrOffsets[5] = self.chrBankOffset(index: Int(self.registers[0] | 0x01))
+            self.chrOffsets[6] = self.chrBankOffset(index: Int(self.registers[1] & 0xFE))
+            self.chrOffsets[7] = self.chrBankOffset(index: Int(self.registers[1] | 0x01))
+        default:
+            break
+        }
+    }
+}

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -5,8 +5,12 @@
 //  Created by Danielle Kefford on 10/28/24.
 //
 
-struct Nrom: Mapper {
+class Nrom: Mapper {
     public unowned var cartridge: Cartridge
+
+    init(cartridge: Cartridge) {
+        self.cartridge = cartridge
+    }
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
@@ -50,7 +54,7 @@ struct Nrom: Mapper {
         }
     }
 
-    mutating func tick(ppu: borrowing PPU) {
+    func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -50,7 +50,7 @@ struct Nrom: Mapper {
         }
     }
 
-    mutating func tick(cpuCycles: Int) {
+    mutating func tick() {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -50,7 +50,7 @@ struct Nrom: Mapper {
         }
     }
 
-    mutating func tick() {
+    mutating func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Nrom.swift
+++ b/happiNESs/Mappers/Nrom.swift
@@ -49,4 +49,8 @@ struct Nrom: Mapper {
             print("Attempted to write to NROM cartridge at address: \(address)")
         }
     }
+
+    mutating func tick(cpuCycles: Int) {
+        // No-op for this mapper type
+    }
 }

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -45,7 +45,7 @@ struct Uxrom: Mapper {
         }
     }
 
-    mutating func tick(cpuCycles: Int) {
+    mutating func tick() {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -5,8 +5,12 @@
 //  Created by Danielle Kefford on 10/28/24.
 //
 
-struct Uxrom: Mapper {
+class Uxrom: Mapper {
     public unowned var cartridge: Cartridge
+
+    init(cartridge: Cartridge) {
+        self.cartridge = cartridge
+    }
 
     public func readByte(address: UInt16) -> UInt8 {
         switch address {
@@ -45,7 +49,7 @@ struct Uxrom: Mapper {
         }
     }
 
-    mutating func tick(ppu: borrowing PPU) {
+    func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -44,4 +44,8 @@ struct Uxrom: Mapper {
             print("Attempted to write to NROM cartridge at address: \(address)")
         }
     }
+
+    mutating func tick(cpuCycles: Int) {
+        // No-op for this mapper type
+    }
 }

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -45,7 +45,7 @@ struct Uxrom: Mapper {
         }
     }
 
-    mutating func tick() {
+    mutating func tick(ppu: borrowing PPU) {
         // No-op for this mapper type
     }
 }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -242,6 +242,7 @@ public struct PPU {
             self.handleNmiState()
             self.handleRendering()
             self.handleCaching()
+            self.cartridge!.mapper.tick(ppu: self)
             redrawScreen = self.handleVerticalBlank() || redrawScreen
             self.handleFrameCounts()
         }

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -231,14 +231,14 @@ public struct PPU {
         }
     }
 
-    // The return value below ultimately reflects whether or not
-    // we need to redraw the screen.
-    //
-    // TODO: Need to rename this function and the one in APU as well
-    mutating func tick(cpuCycles: Int) -> Bool {
+    // This function needs to execute the sequence of instructions three
+    // times for every tick of the CPU since the PPU runs at three times
+    // its clock rate. The return value below ultimately reflects whether
+    // or not we need to redraw the screen.
+    mutating func tick() -> Bool {
         var redrawScreen = false
 
-        for _ in 0 ..< cpuCycles * 3 {
+        for _ in 0 ..< 3 {
             self.handleNmiState()
             self.handleRendering()
             self.handleCaching()

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -59,7 +59,9 @@ import SwiftUI
     }
 
     public func runGame(fileUrl: URL) throws {
-        let cartridge = try Cartridge(cartridgeUrl: fileUrl, saveDataFileDirectory: self.saveDataFileDirectory)
+        let cartridge = try Cartridge(cartridgeUrl: fileUrl,
+                                      saveDataFileDirectory: self.saveDataFileDirectory,
+                                      bus: self.cpu.bus)
         if cartridge.hasBattery {
             try cartridge.loadSram()
         }


### PR DESCRIPTION
This PR is fairly straightforward in intent, namely to implement the MMC3 mapper, but its execution involves some significant changes to the data model for the emulator. This was because this particular cartridge needs to be able to "tick" in sync with the PPU, as well as be able to generate an IRQ in the CPU. And so the following changes needed to be made:

* The `Mapper` protocol now has a `tick()` method.
* All of the extant mappers needed empty implementations of that new method.
* The new `Mmc3` mapper needs to have a reference to the `Bus` so that eventually it can call its `triggerIrq()` method. This required "threading" the reference to the `Bus` instance all the way from the `Console` instance, through the `Cartridge` instance for the ROM file, through the `makeMapper()` method of the correspondent `MapperNumber` case, and then finally to the `Mmc3` instance. Note that the `Mmc3` mapper is the _only_ one that takes a `Bus` instance. 
* For the memory mapping, I ported the implementation of the MMC3 mapper in Michael Fogelman's NES emulator. 
* The new mapper is the only one with an actual implementation for its `tick()` method, which is ultimately is where an IRQ can be triggered under the right conditions.

There also needed to be some reworking of the timing of the various `tick()` methods for the CPU, PPU, and APU, as well as now the relevant mapper. This took a little bit of tinkering in order to optimize the performance, and in the case of Kirby's Adventure, getting the timing right in order for the HUD to stay fixed in position. In short, the `tick`ing of the mapper needs to be done in sync with that of the PPU, and such that the mapper always has access to the current state of the PPU. If this wasn't ensured, the result was, at least in the Kirby game, that the HUD would jump around by a few pixels. Additionally, instead of the PPU ticking for 3n CPU cycles and then the APU ticking for n CPU cycles, the ticking for each are interleaved. This should hopefully avoid any lag in audio.

At some point a performance issue became more profound, namely lag in audio in games like Super Mario Bros. when scrolling backwards. After some amount of experimentation, it turned out that making each mapper a `class` instead of a `struct` resulted in perfect performance. And so the `Mapper` protocol now enforces conformance to `AnyObject` so that any future mappers must also be classes. Additionally, it turns out that running my MacBae Air on low power mode _also_ disaffects performance, and I need to make sure I turn that off when playing games!

This PR also includes a tiny fix for a significant bug, namely that for cartridges that can generate IRQs from the _APU_, the program could hang. This was the case for Rampart. The fix was that I needed to check the status of an IRQ enabled flag in the APU before triggering an IRQ in the CPU. Once a simply `if` check was in place, the game runs perfectly.