### PR TITLE
Fix Marble Madness

### DIFF
--- a/happiNESs/Mirroring.swift
+++ b/happiNESs/Mirroring.swift
@@ -5,10 +5,56 @@
 //  Created by Danielle Kefford on 7/4/24.
 //
 
-public enum Mirroring {
-    case vertical
-    case horizontal
-    case singleScreen0
-    case singleScreen1
-    case fourScreen
+public enum Mirroring: Int {
+    // The actual "physical" layout of the nametables in the PPU VRAM is
+    // the following:
+    //
+    //     [ A ] [ B ]
+    //
+    // where A is the primary nametable and B is the secondary nametable,
+    // each with 1024 byte, the first of which allocated for 32 x 30 = 960
+    // tiles, and next 64 bytes which is reserved for the pattern tables.
+    //
+    // However, the way PPU memory addresses map to the nametables depends on
+    // the current mirroring strategy of the cartridge. In PPU address space,
+    // there are virtually _four_ nametables, two of which are mirrors of the
+    // other two:
+    //
+    //     [ 0 ] [ 1 ]
+    //     [ 2 ] [ 3 ]
+    //
+    // And so, we need to map the inbound nametable to the actual one in PPU VRAM.
+    // For example, with vertical mirroring, virtual nametable indices 0 and 2
+    // need to map to actual nametable A, whereas indices 1 and 3 need to map to
+    // B:
+    //
+    //     [ A ] [ B ]
+    //     [ A ] [ B ]
+    //
+    // For horizontal mirroring, virtual nametable indices 0 and 1 need to map to
+    // actual nametable A, whereas indices 2 and 3 need to map to B:
+    //
+    //     [ A ] [ A ]
+    //     [ B ] [ B ]
+    //
+    // The two-dimensional array below encapsulates these mappings, with the
+    // raw value of the mirroring strategy as the first index, and the inbound
+    // nametable index as the second index.
+    static let nametableIndexLookup: [[Int]] = [
+        [0, 0, 1, 1],
+        [0, 1, 0, 1],
+        [0, 0, 0, 0],
+        [1, 1, 1, 1],
+        [0, 1, 2, 3],
+    ]
+
+    case horizontal = 0
+    case vertical = 1
+    case singleScreen0 = 2
+    case singleScreen1 = 3
+    case fourScreen = 4
+
+    public func actualNametableIndex(for nametableIndex: Int) -> Int {
+        Self.nametableIndexLookup[self.rawValue][nametableIndex]
+    }
 }

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -150,57 +150,11 @@ extension PPU {
 
     private func vramIndex(from address: UInt16) -> Int {
         // Mirror down 0x3000-0x3EFF to 0x2000-0x2EFF
-        let mirroredVramAddress = address & 0b0010_1111_1111_1111
-
-        let addressOffset = Int(mirroredVramAddress - Self.ppuAddressSpaceStart)
-        let nameTableIndex = addressOffset / Self.nametableSize
-        let nameTableOffset = addressOffset % Self.nametableSize
-
-        // The actual "physical" layout of the nametables in the PPU VRAM is
-        // the following:
-        //
-        //     [ A ] [ B ]
-        //
-        // where A is the primary nametable and B is the secondary nametable,
-        // each with 32 x 30 = 960 bytes. (The next 64 bytes for each is reserved
-        // for the pattern tables.)
-        //
-        // However, the way PPU memory addresses map to the nametables depends on
-        // the mirroring strategy hardcoded into the ROM, and thus set in the PPU.
-        // In PPU address space, there are virtually _four_ nametables, two of which
-        // are mirrors of the other two:
-        //
-        //     [ 0 ] [ 1 ]
-        //     [ 2 ] [ 3 ]
-        //
-        // And so, we need to map the requested memory address to the correct index
-        // of the PPU VRAM array. For vertical mirroring, virtual nametable indices 0 and 2
-        // need to map to actual nametable A, whereas indices 1 and 3 need to map to
-        // B:
-        //
-        //     [ A ] [ B ]
-        //     [ A ] [ B ]
-        //
-        // For horizontal mirroring, virtual nametable indices 0 and 1 need to map to
-        // actual nametable A, whereas indices 2 and 3 need to map to B:
-        //
-        //     [ A ] [ A ]
-        //     [ B ] [ B ]
-        //
-        // And so, the `let` statement below maps the tuple of mirroring strategy
-        // and virtual nametable index to the beginning "physical" nametable address.
-        // From there, we can add the nametable offset to get the actual address.
-        // (For now, this emulator only handles vertical and horizontal mirroring.)
-        let actualNametableIndexStart = switch (self.cartridge!.mirroring, nameTableIndex) {
-        case (_, 0), (.horizontal, 1), (.vertical, 2), (.singleScreen0, _):
-            0x0000
-        case (.horizontal, 2), (.vertical, 1), (_, 3), (.singleScreen1, _):
-            0x0400
-        default:
-            fatalError("Invalid nametable index")
-        }
-
-        return actualNametableIndexStart + nameTableOffset
+        let addressOffset = Int(address - Self.ppuAddressSpaceStart) % 0x1000
+        let inboundNametableIndex = addressOffset / Self.nametableSize
+        let nametableOffset = addressOffset % Self.nametableSize
+        let actualNametableIndex = self.cartridge!.mirroring.actualNametableIndex(for: inboundNametableIndex)
+        return actualNametableIndex * 0x400 + nametableOffset
     }
 
     private func paletteIndex(from address: Address) -> Int {

--- a/happiNESs/PPU+caching.swift
+++ b/happiNESs/PPU+caching.swift
@@ -74,7 +74,7 @@ extension PPU {
 
     mutating private func cacheNametableByte() {
         let address = 0x2000 | (self.currentSharedAddress & 0x0FFF)
-        self.currentNametableByte = self.readByte(address: address).result
+        self.currentNametableByte = self.readByteInternal(address: address)
     }
 
     mutating private func cachePaletteIndex() {
@@ -142,7 +142,7 @@ extension PPU {
         let paletteIndexShift = (metatileBlockIndexY << 1 | metatileBlockIndexX) * 2
 
         // ... now actually grab the palette byte using the current attribute address...
-        let paletteByte = self.readByte(address: self.currentAttributeAddress).result
+        let paletteByte = self.readByteInternal(address: self.currentAttributeAddress)
 
         // ... finally, pluck out and cache the two bits representing the palette index
         self.currentPaletteIndex = (paletteByte >> paletteIndexShift) & 0b0000_0011
@@ -154,7 +154,7 @@ extension PPU {
                                               bitPlaneIndex: false,
                                               fineY: self.currentSharedAddress[.fineY])
 
-        self.currentLowTileByte = self.readByte(address: address).result
+        self.currentLowTileByte = self.readByteInternal(address: address)
     }
 
     mutating private func cacheHighTileByte() {
@@ -163,7 +163,7 @@ extension PPU {
                                               bitPlaneIndex: true,
                                               fineY: self.currentSharedAddress[.fineY])
 
-        self.currentHighTileByte = self.readByte(address: address).result
+        self.currentHighTileByte = self.readByteInternal(address: address)
     }
 
     mutating private func cacheTileData() {
@@ -247,8 +247,8 @@ extension PPU {
                                                       tileIndex: tileIndex,
                                                       bitPlaneIndex: true,
                                                       fineY: UInt8(spritePixelY))
-        var lowTileByte = self.readByte(address: lowTileAddress).result
-        var highTileByte = self.readByte(address: highTileAddress).result
+        var lowTileByte = self.readByteInternal(address: lowTileAddress)
+        var highTileByte = self.readByteInternal(address: highTileAddress)
         let paletteBits = (attributeByte & 0b11) << 2
 
         // Here we're caching the palette information for the current sprite.

--- a/happiNESs/PPU+tracing.swift
+++ b/happiNESs/PPU+tracing.swift
@@ -9,8 +9,8 @@ extension PPU {
     public func dump() {
         print("cycles: \(cycles), scanline: \(scanline)")
         dumpSprites()
-        dumpNametable(vram.prefix(2048), labeled: "A")
-        dumpNametable(vram.suffix(2048), labeled: "B")
+        dumpNametable(vram.prefix(0x0400), labeled: "A")
+        dumpNametable(vram.suffix(0x0400), labeled: "B")
     }
 
     func dumpSprites() {
@@ -40,7 +40,7 @@ extension PPU {
             print("- tiles: ", terminator: "")
             for column in 0..<32 {
                 let i = column + row * 32
-                let tileIndex = Int(nametable[i])
+                let tileIndex = Int(nametable[nametable.startIndex + i])
                 print(String(format: "%2x", tileIndex), terminator: " ")
             }
             print()
@@ -50,7 +50,7 @@ extension PPU {
             print("- attrs: ", terminator: "")
             for column in 0..<16 {
                 let i = column + row * 16
-                let attrs = Int(nametable[i])
+                let attrs = Int(nametable[nametable.startIndex + i])
                 let topLeft = attrs & 0b11
                 let topRight = attrs & 0b1100 >> 2
                 print(String(format: "%2x", topLeft), terminator: " ")
@@ -61,7 +61,7 @@ extension PPU {
             print("         ", terminator: "")
             for column in 0..<16 {
                 let i = column + row * 16
-                let attrs = Int(nametable[i])
+                let attrs = Int(nametable[nametable.startIndex + i])
                 let botLeft = attrs & 0b110000 >> 4
                 let botRight = attrs & 0b11000000 >> 6
                 print(String(format: "%2x", botLeft), terminator: " ")

--- a/happiNESs/PPU.swift
+++ b/happiNESs/PPU.swift
@@ -163,7 +163,6 @@ public struct PPU {
         if self.isRenderingEnabled {
             self.cacheBackgroundTiles()
 
-            // TODO: Revisit this because sprites should be cached for the _next_ line
             if self.isVisibleLine && self.isCacheSpritesCycle {
                 self.cacheSprites()
             }


### PR DESCRIPTION
This PR _finally_ addresses a bug in disaffecting the display of the text boxes at the beginning of each level in Marble Madness; this is what it looked like previously:

![image](https://github.com/user-attachments/assets/ba5bc0de-902c-4a04-9a64-ce162a825318)

After ruling out a _ton_ of other possibilities, namely the implementations behind caching and rendering of tile data by the PPU, it turned out that it was a fairly trivial mapping issue. In the case of the Marble Madness game, it uses the `singleScreen1` mirroring strategy and previously we were incorrectly computing actual nametable indices for it. 

The fix was to update the mapping, this time representing it as a two-dimensional array instead of a switch/case statement. Also the mapping has been moved into the `Mirroring` enum, and an instance method added there to return the correct nametable index for a given mirroring strategy and inbound nametable index. And now everything renders perfectly:

![image](https://github.com/user-attachments/assets/7c7a9c0b-d0a6-4686-a1c2-8b33706408ef)

Other fixes/updates included in this PR:

* Subtle bug fix in the reading PPU memory in the range 0x3F00-0x3FFF; we hadn't been properly setting the buffer value previously.
* We also changed the internal API a little bit so that `readByteInternal()` no longer returns a tuple.
* The PPU dump utility also had a few bugs that resulted in the output being incorrect.