### PR TITLE
Make clearer the relationship between mirroring strategy and nametable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ So far, the following mappers and associated games have been tested in this emul
   - Rampart
 - 007
   - Sky Shark
-  - Marble Madness (text box glitches a little at start of level)
+  - Marble Madness
   - Wheel of Fortune
 
 Also, this emulator now supports sound! Games should play and sound _pretty_ close to the original, however certain things like timings and IRQ interrupt handling may not be quite right and will need some work to correct.

--- a/happiNESs/Mirroring.swift
+++ b/happiNESs/Mirroring.swift
@@ -5,6 +5,13 @@
 //  Created by Danielle Kefford on 7/4/24.
 //
 
+public enum Nametable: Int {
+    case a = 0x0000
+    case b = 0x0400
+    case c = 0x0800
+    case d = 0x0B00
+}
+
 public enum Mirroring: Int {
     // The actual "physical" layout of the nametables in the PPU VRAM is
     // the following:
@@ -40,12 +47,12 @@ public enum Mirroring: Int {
     // The two-dimensional array below encapsulates these mappings, with the
     // raw value of the mirroring strategy as the first index, and the inbound
     // nametable index as the second index.
-    static let nametableIndexLookup: [[Int]] = [
-        [0, 0, 1, 1],
-        [0, 1, 0, 1],
-        [0, 0, 0, 0],
-        [1, 1, 1, 1],
-        [0, 1, 2, 3],
+    static let nametableLookup: [[Nametable]] = [
+        [.a, .a, .b, .b],
+        [.a, .b, .a, .b],
+        [.a, .a, .a, .a],
+        [.b, .b, .b, .b],
+        [.a, .b, .c, .d],
     ]
 
     case horizontal = 0
@@ -54,7 +61,7 @@ public enum Mirroring: Int {
     case singleScreen1 = 3
     case fourScreen = 4
 
-    public func actualNametableIndex(for nametableIndex: Int) -> Int {
-        Self.nametableIndexLookup[self.rawValue][nametableIndex]
+    public func actualNametable(for nametableIndex: Int) -> Nametable {
+        Self.nametableLookup[self.rawValue][nametableIndex]
     }
 }

--- a/happiNESs/PPU+IO.swift
+++ b/happiNESs/PPU+IO.swift
@@ -153,8 +153,8 @@ extension PPU {
         let addressOffset = Int(address - Self.ppuAddressSpaceStart) % 0x1000
         let inboundNametableIndex = addressOffset / Self.nametableSize
         let nametableOffset = addressOffset % Self.nametableSize
-        let actualNametableIndex = self.cartridge!.mirroring.actualNametableIndex(for: inboundNametableIndex)
-        return actualNametableIndex * 0x400 + nametableOffset
+        let actualNametable = self.cartridge!.mirroring.actualNametable(for: inboundNametableIndex)
+        return actualNametable.rawValue + nametableOffset
     }
 
     private func paletteIndex(from address: Address) -> Int {


### PR DESCRIPTION
This is a tiny PR which makes it a lot clearer how VRAM indices are computed for a given mirroring strategy and inbound nametable index. 

The README was also updated since I had forgotten to do so in the previous PR.