### PR TITLE
Fix unit tests for `Cartridge`

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		878D81472C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878D81482C815E760076ED30 /* NESError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878D81462C815E760076ED30 /* NESError.swift */; };
 		878DCB8D2CCAB4CC00BE7ABB /* NoiseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */; };
+		879F665B2D0FB1BC00DF8AB1 /* Interruptible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879F665A2D0FB1B500DF8AB1 /* Interruptible.swift */; };
 		87C5B3272CD9C3C9008580A6 /* Axrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3222CD9C3C9008580A6 /* Axrom.swift */; };
 		87C5B3282CD9C3C9008580A6 /* Cnrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3232CD9C3C9008580A6 /* Cnrom.swift */; };
 		87C5B3292CD9C3C9008580A6 /* Mmc1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B3242CD9C3C9008580A6 /* Mmc1.swift */; };
@@ -181,6 +182,7 @@
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
 		878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseChannel.swift; sourceTree = "<group>"; };
+		879F665A2D0FB1B500DF8AB1 /* Interruptible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interruptible.swift; sourceTree = "<group>"; };
 		87C5B3222CD9C3C9008580A6 /* Axrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Axrom.swift; sourceTree = "<group>"; };
 		87C5B3232CD9C3C9008580A6 /* Cnrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cnrom.swift; sourceTree = "<group>"; };
 		87C5B3242CD9C3C9008580A6 /* Mmc1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mmc1.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				87F234572CE8573F00D2FDA6 /* FilterChain.swift */,
 				87F234542CE856C400D2FDA6 /* Filters */,
 				8771BFA72CCD62C500306E13 /* Interrupt.swift */,
+				879F665A2D0FB1B500DF8AB1 /* Interruptible.swift */,
 				877E970A2C7E4716007513B5 /* Joypad.swift */,
 				871932042C30C6DC00A73C22 /* JoypadButton.swift */,
 				87E981462CD076660090A200 /* Mapper.swift */,
@@ -623,6 +626,7 @@
 				87F2345A2CE85E0100D2FDA6 /* HighPassFilter.swift in Sources */,
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
+				879F665B2D0FB1BC00DF8AB1 /* Interruptible.swift in Sources */,
 				874F51AF2CBF10DA00B12037 /* TriangleChannel.swift in Sources */,
 				871932142C3798B400A73C22 /* Cartridge.swift in Sources */,
 				87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */,

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		875F1ED12CCC7D0000DC8B7F /* DMCChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */; };
 		8763D0652C386A17006C1B4F /* snake.nes in Resources */ = {isa = PBXBuildFile; fileRef = 8763D0642C386A17006C1B4F /* snake.nes */; };
 		8763D0682C39B61F006C1B4F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0672C39B61F006C1B4F /* Helpers.swift */; };
-		8763D06A2C39B719006C1B4F /* RomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0692C39B719006C1B4F /* RomTests.swift */; };
+		8763D06A2C39B719006C1B4F /* CartridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D0692C39B719006C1B4F /* CartridgeTests.swift */; };
 		8763D06C2C39E528006C1B4F /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06B2C39E528006C1B4F /* Screen.swift */; };
 		8763D06E2C3A340C006C1B4F /* Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763D06D2C3A340C006C1B4F /* Tracing.swift */; };
 		8771BFA82CCD62C500306E13 /* Interrupt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8771BFA72CCD62C500306E13 /* Interrupt.swift */; };
@@ -171,7 +171,7 @@
 		875F1ED02CCC7D0000DC8B7F /* DMCChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMCChannel.swift; sourceTree = "<group>"; };
 		8763D0642C386A17006C1B4F /* snake.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = snake.nes; sourceTree = "<group>"; };
 		8763D0672C39B61F006C1B4F /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
-		8763D0692C39B719006C1B4F /* RomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RomTests.swift; sourceTree = "<group>"; };
+		8763D0692C39B719006C1B4F /* CartridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartridgeTests.swift; sourceTree = "<group>"; };
 		8763D06B2C39E528006C1B4F /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		8763D06D2C3A340C006C1B4F /* Tracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracing.swift; sourceTree = "<group>"; };
 		8771BFA72CCD62C500306E13 /* Interrupt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interrupt.swift; sourceTree = "<group>"; };
@@ -379,7 +379,7 @@
 				87E981542CD9A6170090A200 /* roms */,
 				8744B1812C1CB9B3001B44B5 /* CPUTests.swift */,
 				8763D0672C39B61F006C1B4F /* Helpers.swift */,
-				8763D0692C39B719006C1B4F /* RomTests.swift */,
+				8763D0692C39B719006C1B4F /* CartridgeTests.swift */,
 			);
 			path = happiNESsTests;
 			sourceTree = "<group>";
@@ -647,7 +647,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8763D06A2C39B719006C1B4F /* RomTests.swift in Sources */,
+				8763D06A2C39B719006C1B4F /* CartridgeTests.swift in Sources */,
 				8744B1822C1CB9B3001B44B5 /* CPUTests.swift in Sources */,
 				8763D0682C39B61F006C1B4F /* Helpers.swift in Sources */,
 			);

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -108,7 +108,7 @@ extension Bus {
     }
 }
 
-extension Bus {
+extension Bus: Interruptible {
     public func triggerNmi() {
         self.cpu!.interrupt = .nmi
     }

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -12,7 +12,7 @@ public class Cartridge {
 
     public var cartridgeUrl: URL
     public var saveDataFilePath: URL
-    public var bus: Bus
+    public var interruptible: Interruptible
     public var hasBattery: Bool
     public var timingMode: TimingMode
     public var mirroring: Mirroring
@@ -28,11 +28,11 @@ public class Cartridge {
         }
     }
 
-    public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self, bus: self.bus)
+    public lazy var mapper: Mapper = mapperNumber.makeMapper(cartridge: self, interruptible: self.interruptible)
 
     public init(cartridgeUrl: URL,
                 saveDataFileDirectory: URL,
-                bus: Bus) throws {
+                interruptible: Interruptible) throws {
         let data: Data = try Data(contentsOf: cartridgeUrl)
         let bytes = [UInt8](data)
 
@@ -140,7 +140,7 @@ public class Cartridge {
         self.prgBankIndex = 0
         self.chrMemory = chrMemory
         self.chrBankIndex = 0
-        self.bus = bus
+        self.interruptible = interruptible
     }
 
     public func readByte(address: UInt16) -> UInt8 {

--- a/happiNESs/Cartridge.swift
+++ b/happiNESs/Cartridge.swift
@@ -20,7 +20,7 @@ public class Cartridge {
     public var chrMemory: [UInt8]
     public var chrBankIndex: Int
     public var isSramDirty: Bool = false
-    public var sram: [UInt8] {
+    public var sram: Data {
         didSet {
             self.isSramDirty = true
         }
@@ -116,7 +116,7 @@ public class Cartridge {
         }
 
         self.hasBattery = hasBattery
-        self.sram = [UInt8](repeating: 0x00, count: 0x2000)
+        self.sram = Data(repeating: 0x00, count: 0x2000)
         self.timingMode = timingMode
         self.mirroring = mirroring
         self.prgMemory = prgMemory
@@ -139,13 +139,11 @@ public class Cartridge {
             return
         }
 
-        let sramData = try loadClosure()
-
-        self.sram = [UInt8](sramData)
+        self.sram = try loadClosure()
         self.isSramDirty = false
     }
 
-    public func saveSramIfNeeded(saveClosure: ([UInt8]) throws -> Void) throws {
+    public func saveSramIfNeeded(saveClosure: (Data) throws -> Void) throws {
         if !self.hasBattery {
             return
         }

--- a/happiNESs/Interruptible.swift
+++ b/happiNESs/Interruptible.swift
@@ -1,0 +1,11 @@
+//
+//  Interruptible.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 12/15/24.
+//
+
+public protocol Interruptible {
+    func triggerNmi()
+    func triggerIrq()
+}

--- a/happiNESs/MapperNumber.swift
+++ b/happiNESs/MapperNumber.swift
@@ -13,7 +13,7 @@ public enum MapperNumber: UInt16 {
     case mmc3 = 4
     case axrom = 7
 
-    public func makeMapper(cartridge: Cartridge, bus: Bus) -> Mapper {
+    public func makeMapper(cartridge: Cartridge, interruptible: Interruptible) -> Mapper {
         switch self {
         case .nrom:
             return Nrom(cartridge: cartridge)
@@ -24,7 +24,7 @@ public enum MapperNumber: UInt16 {
         case .cnrom:
             return Cnrom(cartridge: cartridge)
         case .mmc3:
-            return Mmc3(cartridge: cartridge, bus: bus)
+            return Mmc3(cartridge: cartridge, interruptible: interruptible)
         case .axrom:
             return Axrom(cartridge: cartridge)
         }

--- a/happiNESs/Mappers/Mmc3.swift
+++ b/happiNESs/Mappers/Mmc3.swift
@@ -8,7 +8,7 @@
 class Mmc3: Mapper {
     public unowned var cartridge: Cartridge
 
-    private var bus: Bus
+    private var interruptible: Interruptible
     private var prgRomBankMode: UInt8 = 0
     private var chrRomBankMode: UInt8 = 0
     private var registerIndex: Int = 0
@@ -19,9 +19,9 @@ class Mmc3: Mapper {
     private var irqCounterReload: UInt8 = 0
     private var irqEnabled: Bool = false
 
-    init(cartridge: Cartridge, bus: Bus) {
+    init(cartridge: Cartridge, interruptible: Interruptible) {
         self.cartridge = cartridge
-        self.bus = bus
+        self.interruptible = interruptible
 
         self.prgOffsets[0] = self.prgBankOffset(index: 0)
         self.prgOffsets[1] = self.prgBankOffset(index: 1)
@@ -76,7 +76,7 @@ class Mmc3: Mapper {
             self.irqCounter -= 1
 
             if self.irqCounter == 0 && self.irqEnabled {
-                self.bus.triggerIrq()
+                self.interruptible.triggerIrq()
             }
         }
     }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -60,8 +60,8 @@ import SwiftUI
     }
 
     public func runGame(fileUrl: URL) throws {
-        let cartridge = try Cartridge(cartridgeUrl: fileUrl,
-                                      saveDataFileDirectory: self.saveDataFileDirectory,
+        let romData: Data = try Data(contentsOf: fileUrl)
+        let cartridge = try Cartridge(romData: romData,
                                       interruptible: self.cpu.bus)
         if cartridge.hasBattery {
             try cartridge.loadSram()

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -62,7 +62,7 @@ import SwiftUI
     public func runGame(fileUrl: URL) throws {
         let cartridge = try Cartridge(cartridgeUrl: fileUrl,
                                       saveDataFileDirectory: self.saveDataFileDirectory,
-                                      bus: self.cpu.bus)
+                                      interruptible: self.cpu.bus)
         if cartridge.hasBattery {
             try cartridge.loadSram()
         }

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -153,8 +153,7 @@ import SwiftUI
     public func saveSram() throws {
         do {
             try self.cartridge!.saveSramIfNeeded { sram in
-                let sramData = Data(sram)
-                try sramData.write(to: self.saveSramPath!)
+                try sram.write(to: self.saveSramPath!)
                 self.lastSavedDate = Date.now
             }
         } catch let error {

--- a/happiNESsApp/Console.swift
+++ b/happiNESsApp/Console.swift
@@ -27,8 +27,10 @@ import SwiftUI
     public var isPaused: Bool = false
     private var speaker: Speaker
     var cartridgeLoaded: Bool = false
+    private var cartridge: Cartridge?
     var displayTimer: Timer!
-    var saveDataFileDirectory: URL
+    var saveSramDirectory: URL
+    private var saveSramPath: URL?
     public var lastSavedDate: Date = Date.now
     public var currentError: NESError? = nil
 
@@ -49,11 +51,11 @@ import SwiftUI
 
         do {
             let fileManager = FileManager.default
-            self.saveDataFileDirectory = try fileManager.url(for: .applicationSupportDirectory,
+            self.saveSramDirectory = try fileManager.url(for: .applicationSupportDirectory,
                                                              in: .userDomainMask,
                                                              appropriateFor: nil,
                                                              create: true).appending(path: "happiNESs")
-            try fileManager.createDirectory(at: saveDataFileDirectory, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: saveSramDirectory, withIntermediateDirectories: true)
         } catch {
             throw NESError.cannotCreateSaveDataDirectory
         }
@@ -63,9 +65,19 @@ import SwiftUI
         let romData: Data = try Data(contentsOf: fileUrl)
         let cartridge = try Cartridge(romData: romData,
                                       interruptible: self.cpu.bus)
-        if cartridge.hasBattery {
-            try cartridge.loadSram()
+
+        let romFileName = fileUrl.lastPathComponent
+        var saveSramFilename: String
+        if let index = romFileName.lastIndex(of: ".") {
+            let sramPrefix = String(romFileName.prefix(upTo: index))
+            saveSramFilename = sramPrefix + ".dat"
+        } else {
+            saveSramFilename = romFileName + ".dat"
         }
+        self.saveSramPath = saveSramDirectory.appendingPathComponent(saveSramFilename)
+
+        self.cartridge = cartridge
+        try self.loadSram()
 
         self.cpu.loadCartridge(cartridge: cartridge)
         self.cartridgeLoaded = true
@@ -121,10 +133,32 @@ import SwiftUI
         self.cpu.reset()
     }
 
+    public func loadSram() throws {
+        try self.cartridge!.loadSramIfNeeded {
+            var sramData: Data
+            do {
+                sramData = try Data.init(contentsOf: self.saveSramPath!)
+            } catch {
+                sramData = Data(repeating: 0x00, count: 0x2000)
+            }
+
+            if sramData.count != 0x2000 {
+                throw NESError.invalidSaveDatafile
+            }
+
+            return sramData
+        }
+    }
+
     public func saveSram() throws {
-        if self.cpu.bus.cartridge!.hasBattery {
-            try self.cpu.bus.cartridge!.saveSram()
-            self.lastSavedDate = Date.now
+        do {
+            try self.cartridge!.saveSramIfNeeded { sram in
+                let sramData = Data(sram)
+                try sramData.write(to: self.saveSramPath!)
+                self.lastSavedDate = Date.now
+            }
+        } catch let error {
+            throw NESError.unableToSaveDataFile(error.localizedDescription)
         }
     }
 

--- a/happiNESsTests/CartridgeTests.swift
+++ b/happiNESsTests/CartridgeTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import happiNESs
 
-final class RomTests: XCTestCase {
+final class CartridgeTests: XCTestCase {
     func testRomWithBadTag() throws {
         let header: [UInt8] = [
             0x0B, 0xAD, 0x0B, 0xAD,

--- a/happiNESsTests/CartridgeTests.swift
+++ b/happiNESsTests/CartridgeTests.swift
@@ -8,6 +8,16 @@
 import XCTest
 @testable import happiNESs
 
+struct MockBus: Interruptible {
+    func triggerNmi() {
+        // Do nothing
+    }
+
+    func triggerIrq() {
+        // Do nothing
+    }
+}
+
 final class CartridgeTests: XCTestCase {
     func testRomWithBadTag() throws {
         let header: [UInt8] = [

--- a/happiNESsTests/Helpers.swift
+++ b/happiNESsTests/Helpers.swift
@@ -7,6 +7,16 @@
 
 @testable import happiNESs
 
+struct MockBus: Interruptible {
+    func triggerNmi() {
+        // Do nothing
+    }
+
+    func triggerIrq() {
+        // Do nothing
+    }
+}
+
 func makeCartridge(programBytes: [UInt8]) -> Cartridge {
     let header: [UInt8] = [
         0x4E, 0x45, 0x53, 0x1A,
@@ -15,14 +25,15 @@ func makeCartridge(programBytes: [UInt8]) -> Cartridge {
     let prgRomBytes = Array(repeating: 0x00, count: 0x0600) + programBytes + Array(repeating: 0x00, count: 0x79FC - programBytes.count) + [0x00, 0x86, 0x00, 0x00]
     let chrRomBytes = [UInt8](repeating: 0x00, count: 8192)
     let romBytes = header + prgRomBytes + chrRomBytes
+    let romData = Data(romBytes)
 
-    return try! Cartridge(bytes: romBytes)
+    return try! Cartridge(romData: romData, interruptible: MockBus())
 }
 
 func makeCpu(programBytes: [UInt8]) -> CPU {
     let cartridge = makeCartridge(programBytes: programBytes)
     let bus = Bus()
-    var cpu = CPU(bus: bus)
+    let cpu = CPU(bus: bus)
     cpu.loadCartridge(cartridge: cartridge)
     cpu.reset()
 


### PR DESCRIPTION
This PR was not intended to be as substantial as it wound up being, but was necessary in order to fulfill its primary purpose: to restore the functionality of all the unit tests.

Specifically, changes to the initializer for the `Cartridge` class broke the set of its unit tests. Even though the emulator was fully functional, I realized that it didn't really make sense for `Cartridge` to have any knowledge of file I/O, let alone its being burdensome to have to pass in a full-fledged `Bus` object in order to instantiate one in the context of a unit test. And so now `Cartridge` and `Console` have been refactored such that all logic having to do with file I/O is managed in the latter, and all logic having to do with the state of SRAM is managed in the former. In addition to that refactoring, I needed to introduce a new `Interruptible` protocol, which allows for a mock `Bus` object to be passed to `Cartridge` in the context of a unit test, with methods normally for handling interrupts but instead are no-ops. And because it makes things easier, I switched the type of the SRAM field in `Cartridge` to `Data`, and all methods that handle it.

The end result is that all of the tests in the entire test suite now compile and pass again.