### PR TITLE
Get blargg's APU tests passing

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		87DC93682D2471DF008D65D2 /* LengthCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC93672D2471DA008D65D2 /* LengthCounter.swift */; };
 		87DC936A2D247F4F008D65D2 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC93692D247F4C008D65D2 /* Timer.swift */; };
 		87DC936C2D248527008D65D2 /* Envelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC936B2D248523008D65D2 /* Envelope.swift */; };
+		87DC936E2D28BE54008D65D2 /* apu_test.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87DC936D2D28BE54008D65D2 /* apu_test.nes */; };
 		87E981472CD076660090A200 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981462CD076660090A200 /* Mapper.swift */; };
 		87E981532CD8B5990090A200 /* NMIDelayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981522CD8B5990090A200 /* NMIDelayState.swift */; };
 		87E981562CD9A6950090A200 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87E981552CD9A6950090A200 /* nestest.nes */; };
@@ -205,6 +206,7 @@
 		87DC93672D2471DA008D65D2 /* LengthCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LengthCounter.swift; sourceTree = "<group>"; };
 		87DC93692D247F4C008D65D2 /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		87DC936B2D248523008D65D2 /* Envelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Envelope.swift; sourceTree = "<group>"; };
+		87DC936D2D28BE54008D65D2 /* apu_test.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = apu_test.nes; sourceTree = "<group>"; };
 		87E981462CD076660090A200 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
 		87E981522CD8B5990090A200 /* NMIDelayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMIDelayState.swift; sourceTree = "<group>"; };
 		87E981552CD9A6950090A200 /* nestest.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = nestest.nes; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 		87E981542CD9A6170090A200 /* roms */ = {
 			isa = PBXGroup;
 			children = (
+				87DC936D2D28BE54008D65D2 /* apu_test.nes */,
 				879F66A82D137EDB00DF8AB1 /* test_ppu_read_buffer.nes */,
 				879F66A62D137E9D00DF8AB1 /* official_only.nes */,
 				87E981572CD9A6BF0090A200 /* ppu_vbl_nmi.nes */,
@@ -591,6 +594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				879F66A92D137EDB00DF8AB1 /* test_ppu_read_buffer.nes in Resources */,
+				87DC936E2D28BE54008D65D2 /* apu_test.nes in Resources */,
 				879F66A72D137E9D00DF8AB1 /* official_only.nes in Resources */,
 				87E981582CD9A6BF0090A200 /* ppu_vbl_nmi.nes in Resources */,
 				87E981562CD9A6950090A200 /* nestest.nes in Resources */,

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		87DC936A2D247F4F008D65D2 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC93692D247F4C008D65D2 /* Timer.swift */; };
 		87DC936C2D248527008D65D2 /* Envelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC936B2D248523008D65D2 /* Envelope.swift */; };
 		87DC936E2D28BE54008D65D2 /* apu_test.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87DC936D2D28BE54008D65D2 /* apu_test.nes */; };
+		87DC93702D28C367008D65D2 /* LinearCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC936F2D28C363008D65D2 /* LinearCounter.swift */; };
 		87E981472CD076660090A200 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981462CD076660090A200 /* Mapper.swift */; };
 		87E981532CD8B5990090A200 /* NMIDelayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981522CD8B5990090A200 /* NMIDelayState.swift */; };
 		87E981562CD9A6950090A200 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87E981552CD9A6950090A200 /* nestest.nes */; };
@@ -207,6 +208,7 @@
 		87DC93692D247F4C008D65D2 /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		87DC936B2D248523008D65D2 /* Envelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Envelope.swift; sourceTree = "<group>"; };
 		87DC936D2D28BE54008D65D2 /* apu_test.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = apu_test.nes; sourceTree = "<group>"; };
+		87DC936F2D28C363008D65D2 /* LinearCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinearCounter.swift; sourceTree = "<group>"; };
 		87E981462CD076660090A200 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
 		87E981522CD8B5990090A200 /* NMIDelayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMIDelayState.swift; sourceTree = "<group>"; };
 		87E981552CD9A6950090A200 /* nestest.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = nestest.nes; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 				874F51B42CC1D05D00B12037 /* PulseChannel.swift */,
 				87DC936B2D248523008D65D2 /* Envelope.swift */,
 				87DC93672D2471DA008D65D2 /* LengthCounter.swift */,
+				87DC936F2D28C363008D65D2 /* LinearCounter.swift */,
 				87DC93692D247F4C008D65D2 /* Timer.swift */,
 			);
 			path = Channels;
@@ -653,6 +656,7 @@
 				870AABE02CB37EA000E9F3B6 /* CPU+instructions.swift in Sources */,
 				8771BFA82CCD62C500306E13 /* Interrupt.swift in Sources */,
 				87F2345A2CE85E0100D2FDA6 /* HighPassFilter.swift in Sources */,
+				87DC93702D28C367008D65D2 /* LinearCounter.swift in Sources */,
 				871932102C372F6900A73C22 /* Bus.swift in Sources */,
 				871932122C37985700A73C22 /* Mirroring.swift in Sources */,
 				879F665B2D0FB1BC00DF8AB1 /* Interruptible.swift in Sources */,

--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		87C5B32E2CDD71D9008580A6 /* TimingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5B32D2CDD71D9008580A6 /* TimingMode.swift */; };
 		87D265152C9146F400C143B1 /* ViewPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265142C9146F400C143B1 /* ViewPort.swift */; };
 		87D265172C9DECAF00C143B1 /* MapperNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D265162C9DECAF00C143B1 /* MapperNumber.swift */; };
+		87DC93682D2471DF008D65D2 /* LengthCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC93672D2471DA008D65D2 /* LengthCounter.swift */; };
+		87DC936A2D247F4F008D65D2 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC93692D247F4C008D65D2 /* Timer.swift */; };
+		87DC936C2D248527008D65D2 /* Envelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC936B2D248523008D65D2 /* Envelope.swift */; };
 		87E981472CD076660090A200 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981462CD076660090A200 /* Mapper.swift */; };
 		87E981532CD8B5990090A200 /* NMIDelayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E981522CD8B5990090A200 /* NMIDelayState.swift */; };
 		87E981562CD9A6950090A200 /* nestest.nes in Resources */ = {isa = PBXBuildFile; fileRef = 87E981552CD9A6950090A200 /* nestest.nes */; };
@@ -199,6 +202,9 @@
 		87C5B32D2CDD71D9008580A6 /* TimingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingMode.swift; sourceTree = "<group>"; };
 		87D265142C9146F400C143B1 /* ViewPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPort.swift; sourceTree = "<group>"; };
 		87D265162C9DECAF00C143B1 /* MapperNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapperNumber.swift; sourceTree = "<group>"; };
+		87DC93672D2471DA008D65D2 /* LengthCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LengthCounter.swift; sourceTree = "<group>"; };
+		87DC93692D247F4C008D65D2 /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
+		87DC936B2D248523008D65D2 /* Envelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Envelope.swift; sourceTree = "<group>"; };
 		87E981462CD076660090A200 /* Mapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper.swift; sourceTree = "<group>"; };
 		87E981522CD8B5990090A200 /* NMIDelayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMIDelayState.swift; sourceTree = "<group>"; };
 		87E981552CD9A6950090A200 /* nestest.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = nestest.nes; sourceTree = "<group>"; };
@@ -404,6 +410,9 @@
 				878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */,
 				874F51AE2CBF10DA00B12037 /* TriangleChannel.swift */,
 				874F51B42CC1D05D00B12037 /* PulseChannel.swift */,
+				87DC936B2D248523008D65D2 /* Envelope.swift */,
+				87DC93672D2471DA008D65D2 /* LengthCounter.swift */,
+				87DC93692D247F4C008D65D2 /* Timer.swift */,
 			);
 			path = Channels;
 			sourceTree = "<group>";
@@ -621,8 +630,10 @@
 				874F51A92CBEEBA700B12037 /* APU.swift in Sources */,
 				875F1ED12CCC7D0000DC8B7F /* DMCChannel.swift in Sources */,
 				878C69732CAA424400DA9BD4 /* Address.swift in Sources */,
+				87DC936C2D248527008D65D2 /* Envelope.swift in Sources */,
 				8744B18F2C1CBB46001B44B5 /* Opcode.swift in Sources */,
 				874F51922CB9B51C00B12037 /* CachedSprite.swift in Sources */,
+				87DC93682D2471DF008D65D2 /* LengthCounter.swift in Sources */,
 				87C5B3292CD9C3C9008580A6 /* Mmc1.swift in Sources */,
 				874F51AD2CBF05BC00B12037 /* Register.swift in Sources */,
 				87D265152C9146F400C143B1 /* ViewPort.swift in Sources */,
@@ -651,6 +662,7 @@
 				87C5B3282CD9C3C9008580A6 /* Cnrom.swift in Sources */,
 				870AABD82CB32FAA00E9F3B6 /* PPU+caching.swift in Sources */,
 				87F234532CE8567F00D2FDA6 /* Filter.swift in Sources */,
+				87DC936A2D247F4F008D65D2 /* Timer.swift in Sources */,
 				8744B1772C1CB9B3001B44B5 /* happiNESs.docc in Sources */,
 				874F51B12CC03F1500B12037 /* RegisterBitMask.swift in Sources */,
 				879F66A52D125F4800DF8AB1 /* OpenBus.swift in Sources */,

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -109,7 +109,7 @@ extension APU {
         case 0x4002:
             self.pulse1.writeTimerLow(byte: byte)
         case 0x4003:
-            self.pulse1.writeLengthAndTimerHigh(byte: byte)
+            self.pulse1.writeLengthCounterAndTimerHigh(byte: byte)
         case 0x4004:
             self.pulse2.writeController(byte: byte)
         case 0x4005:
@@ -117,7 +117,7 @@ extension APU {
         case 0x4006:
             self.pulse2.writeTimerLow(byte: byte)
         case 0x4007:
-            self.pulse2.writeLengthAndTimerHigh(byte: byte)
+            self.pulse2.writeLengthCounterAndTimerHigh(byte: byte)
         case 0x4008:
             self.triangle.writeController(byte: byte)
         case 0x4009:
@@ -126,7 +126,7 @@ extension APU {
         case 0x400A:
             self.triangle.writeTimerLow(byte: byte)
         case 0x400B:
-            self.triangle.writeLengthAndTimerHigh(byte: byte)
+            self.triangle.writeLengthCounterAndTimerHigh(byte: byte)
         case 0x400C:
             self.noise.writeController(byte: byte)
         case 0x400D:
@@ -135,7 +135,7 @@ extension APU {
         case 0x400E:
             self.noise.writeLoopAndPeriod(byte: byte)
         case 0x400F:
-            self.noise.writeLength(byte: byte)
+            self.noise.writeLengthCounter(byte: byte)
         case 0x4010:
             self.dmc.writeController(byte: byte)
         case 0x4011:
@@ -331,7 +331,7 @@ extension APU {
     mutating private func stepEnvelope() {
         self.pulse1.stepEnvelope()
         self.pulse2.stepEnvelope()
-        self.triangle.stepCounter()
+        self.triangle.stepLinearCounter()
         self.noise.stepEnvelope()
     }
 
@@ -341,10 +341,10 @@ extension APU {
     }
 
     mutating private func stepLength() {
-        self.pulse1.stepLength()
-        self.pulse2.stepLength()
-        self.triangle.stepLength()
-        self.noise.stepLength()
+        self.pulse1.stepLengthCounter()
+        self.pulse2.stepLengthCounter()
+        self.triangle.stepLengthCounter()
+        self.noise.stepLengthCounter()
     }
 
     mutating private func sendSample() {

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -88,47 +88,47 @@ extension APU {
     mutating public func writeByte(address: UInt16, byte: UInt8) {
         switch address {
         case 0x4000:
-            self.pulse1.updateRegister1(byte: byte)
+            self.pulse1.writeController(byte: byte)
         case 0x4001:
-            self.pulse1.updateRegister2(byte: byte)
+            self.pulse1.writeSweep(byte: byte)
         case 0x4002:
-            self.pulse1.updateRegister3(byte: byte)
+            self.pulse1.writeTimerLow(byte: byte)
         case 0x4003:
-            self.pulse1.updateRegister4(byte: byte)
+            self.pulse1.writeLengthAndTimerHigh(byte: byte)
         case 0x4004:
-            self.pulse2.updateRegister1(byte: byte)
+            self.pulse2.writeController(byte: byte)
         case 0x4005:
-            self.pulse2.updateRegister2(byte: byte)
+            self.pulse2.writeSweep(byte: byte)
         case 0x4006:
-            self.pulse2.updateRegister3(byte: byte)
+            self.pulse2.writeTimerLow(byte: byte)
         case 0x4007:
-            self.pulse2.updateRegister4(byte: byte)
+            self.pulse2.writeLengthAndTimerHigh(byte: byte)
         case 0x4008:
-            self.triangle.updateRegister1(byte: byte)
+            self.triangle.writeController(byte: byte)
         case 0x4009:
             // Unused register
             break
         case 0x400A:
-            self.triangle.updateRegister3(byte: byte)
+            self.triangle.writeTimerLow(byte: byte)
         case 0x400B:
-            self.triangle.updateRegister4(byte: byte)
+            self.triangle.writeLengthAndTimerHigh(byte: byte)
         case 0x400C:
-            self.noise.updateRegister1(byte: byte)
+            self.noise.writeController(byte: byte)
         case 0x400D:
             // Unused register
             break
         case 0x400E:
-            self.noise.updateRegister3(byte: byte)
+            self.noise.writeLoopAndPeriod(byte: byte)
         case 0x400F:
-            self.noise.updateRegister4(byte: byte)
+            self.noise.writeLength(byte: byte)
         case 0x4010:
-            self.dmc.updateRegister1(byte: byte)
+            self.dmc.writeController(byte: byte)
         case 0x4011:
-            self.dmc.updateRegister2(byte: byte)
+            self.dmc.writeLoadCounter(byte: byte)
         case 0x4012:
-            self.dmc.updateRegister3(byte: byte)
+            self.dmc.writeSampleAddress(byte: byte)
         case 0x4013:
-            self.dmc.updateRegister4(byte: byte)
+            self.dmc.writeSampleLength(byte: byte)
         case 0x4015:
             self.updateStatus(byte: byte)
         case 0x4017:

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -241,7 +241,16 @@ extension APU {
         //     "The triangle channel's timer is clocked on every CPU cycle,
         //     but the pulse, noise, and DMC timers are clocked only on every
         //     second CPU cycle and thus produce only even periods."
-
+        //
+        //     https://www.nesdev.org/wiki/APU#Glossary
+        //
+        // However, the NTSC numbers sourced from the wiki are double what they should be:
+        //
+        //     https://www.nesdev.org/wiki/APU_DMC
+        //
+        // This discussion clarifies this:
+        //
+        //     https://forums.nesdev.org/viewtopic.php?t=11277
         if self.cycles % 2 == 0 {
             self.pulse1.stepTimer()
             self.pulse2.stepTimer()
@@ -258,10 +267,6 @@ extension APU {
         // NOTA BENE: Constants used below taken from:
         //
         //     https://github.com/ichirin2501/rgnes/blob/master/nes/apu.go#L16-L19
-        //
-        // Note that the figures are doubled here because the sequencer clocks
-        // at _half_ the rate of the CPU. Also, this is hardcoded to work with
-        // NTSC timings.
         switch self.sequencerMode {
         case .four:
             switch self.sequencerCount {

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -159,16 +159,7 @@ extension APU {
         self.pulse2.setEnabled(enabled: byte[.pulse2Enabled])
         self.triangle.setEnabled(enabled: byte[.triangleEnabled])
         self.noise.setEnabled(enabled: byte[.noiseEnabled])
-        self.dmc.enabled = byte[.dmcEnabled]
-        self.dmc.irqTriggered = false
-
-        if !self.dmc.enabled {
-            self.dmc.currentLength = 0
-        } else {
-            if self.dmc.currentLength == 0 {
-                self.dmc.restart()
-            }
-        }
+        self.dmc.setEnabled(enabled: byte[.dmcEnabled])
     }
 
     mutating public func updateSequencer(byte: UInt8) {

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -83,7 +83,7 @@ extension APU {
         value[.noiseEnabled] = self.noise.lengthCounter.value > 0
         value[.dmcEnabled] = self.dmc.currentLength > 0
         value[.frameIrqEnabled] = self.frameIrqEnabled
-        value[.apuStatusUnused3] = self.dmc.irqEnabled
+        value[.apuStatusUnused3] = self.dmc.irqTriggered
 
         return value
     }
@@ -160,7 +160,7 @@ extension APU {
         self.triangle.setEnabled(enabled: byte[.triangleEnabled])
         self.noise.setEnabled(enabled: byte[.noiseEnabled])
         self.dmc.enabled = byte[.dmcEnabled]
-        self.dmc.irqEnabled = false
+        self.dmc.irqTriggered = false
 
         if !self.dmc.enabled {
             self.dmc.currentLength = 0

--- a/happiNESs/Channels/DMCChannel.swift
+++ b/happiNESs/Channels/DMCChannel.swift
@@ -51,6 +51,19 @@ public struct DMCChannel {
 }
 
 extension DMCChannel {
+    mutating public func setEnabled(enabled: Bool) {
+        self.enabled = enabled
+        self.irqTriggered = false
+
+        if !self.enabled {
+            self.currentLength = 0
+        } else {
+            if self.currentLength == 0 {
+                self.restart()
+            }
+        }
+    }
+
     mutating public func writeController(byte: UInt8) {
         self.irqEnabled = byte[.dmcIrqEnabled] == 1
         if !self.irqEnabled {

--- a/happiNESs/Channels/DMCChannel.swift
+++ b/happiNESs/Channels/DMCChannel.swift
@@ -57,7 +57,7 @@ extension DMCChannel {
             self.irqTriggered = false
         }
         self.loopEnabled = byte[.dmcLoopEnabled] == 1
-        self.loopPeriod = Self.periodTable[Int(byte[.dmcPeriod])]
+        self.loopPeriod = Self.periodTable[Int(byte[.dmcPeriod])] - 1
     }
 
     mutating public func writeLoadCounter(byte: UInt8) {

--- a/happiNESs/Channels/DMCChannel.swift
+++ b/happiNESs/Channels/DMCChannel.swift
@@ -49,21 +49,21 @@ public struct DMCChannel {
 }
 
 extension DMCChannel {
-    mutating public func updateRegister1(byte: UInt8) {
+    mutating public func writeController(byte: UInt8) {
         self.irqEnabled = byte[.dmcIrqEnabled] == 1
         self.loopEnabled = byte[.dmcLoopEnabled] == 1
         self.loopPeriod = Self.periodTable[Int(byte[.dmcPeriod])]
     }
 
-    mutating public func updateRegister2(byte: UInt8) {
+    mutating public func writeLoadCounter(byte: UInt8) {
         self.loadCounter = byte[.dmcLoadCounter]
     }
 
-    mutating public func updateRegister3(byte: UInt8) {
+    mutating public func writeSampleAddress(byte: UInt8) {
         self.sampleAddress = 0xC000 | (UInt16(byte) << 6)
     }
 
-    mutating public func updateRegister4(byte: UInt8) {
+    mutating public func writeSampleLength(byte: UInt8) {
         self.sampleLength = (UInt16(byte) << 4) | 0x0001
     }
 }

--- a/happiNESs/Channels/DMCChannel.swift
+++ b/happiNESs/Channels/DMCChannel.swift
@@ -13,7 +13,7 @@ public struct DMCChannel {
     public var bus: Bus? = nil
     public var enabled: Bool = false
 
-    private var irqEnabled: Bool = false
+    public var irqEnabled: Bool = false
     private var loopEnabled: Bool = false
     private var loopPeriod: UInt8 = 0x00
     private var loopValue: UInt8 = 0x00

--- a/happiNESs/Channels/Envelope.swift
+++ b/happiNESs/Channels/Envelope.swift
@@ -1,0 +1,46 @@
+//
+//  Envelope.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 12/31/24.
+//
+
+struct Envelope {
+    public var constantVolume: Bool = false
+    public var loopEnabled: Bool = false
+    public var started: Bool = false
+    public var timer: Timer = Timer()
+    public var decayValue: UInt8 = 0
+
+    mutating public func reset() {
+        self.constantVolume = false
+        self.loopEnabled = false
+        self.started = false
+        self.timer.reset()
+        self.decayValue = 0
+    }
+}
+
+extension Envelope {
+    public func getSample() -> UInt8 {
+        if self.constantVolume {
+            return UInt8(self.timer.period)
+        } else {
+            return self.decayValue
+        }
+    }
+
+    mutating public func step() {
+        if self.started {
+            self.started = false
+            self.decayValue = 15
+            self.timer.reload()
+        } else if self.timer.step() {
+            if self.decayValue > 0 {
+                self.decayValue -= 1
+            } else if self.loopEnabled {
+                self.decayValue = 15
+            }
+        }
+    }
+}

--- a/happiNESs/Channels/LengthCounter.swift
+++ b/happiNESs/Channels/LengthCounter.swift
@@ -1,0 +1,48 @@
+//
+//  LengthCounter.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 12/31/24.
+//
+
+public struct LengthCounter {
+    private static let table: [UInt8] = [
+        10, 254, 20, 2, 40, 4, 80, 6,
+        160, 8, 60, 10, 14, 12, 26, 14,
+        12, 16, 24, 18, 48, 20, 96, 22,
+        192, 24, 72, 26, 16, 28, 32, 30,
+    ]
+
+    public var enabled: Bool = false
+    public var halted: Bool = false
+    public var value: UInt8 = 0
+
+    mutating public func reset() {
+        self.enabled = false
+        self.halted = false
+        self.value = 0
+    }
+}
+
+extension LengthCounter {
+    mutating public func setEnabled(enabled: Bool) {
+        if enabled {
+            self.enabled = true
+        } else {
+            self.enabled = false
+            self.value = 0
+        }
+    }
+
+    mutating public func setValue(index: UInt8) {
+        if self.enabled {
+            self.value = Self.table[Int(index)]
+        }
+    }
+
+    mutating public func step() {
+        if !self.halted && self.value > 0 {
+            self.value -= 1
+        }
+    }
+}

--- a/happiNESs/Channels/LinearCounter.swift
+++ b/happiNESs/Channels/LinearCounter.swift
@@ -1,0 +1,34 @@
+//
+//  LinearCounter.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 1/3/25.
+//
+
+public struct LinearCounter {
+    public var enabled: Bool = false
+    public var reload: Bool = false
+    public var period: UInt8 = 0x00
+    public var value: UInt8 = 0x00
+
+    mutating public func reset() {
+        self.enabled = false
+        self.reload = false
+        self.period = 0x00
+        self.value = 0x00
+    }
+}
+
+extension LinearCounter {
+    mutating public func step() {
+        if self.reload {
+            self.value = self.period
+        } else if self.value > 0 {
+            self.value -= 1
+        }
+
+        if !self.enabled {
+            self.reload = false
+        }
+    }
+}

--- a/happiNESs/Channels/NoiseChannel.swift
+++ b/happiNESs/Channels/NoiseChannel.swift
@@ -50,7 +50,7 @@ public struct NoiseChannel {
 }
 
 extension NoiseChannel {
-    mutating public func updateRegister1(byte: UInt8) {
+    mutating public func writeController(byte: UInt8) {
         self.controlFlag = byte[.noiseControlFlag] == 1 ? .envelopeLoop : .lengthCounterEnabled
         self.constantVolumeFlag = byte[.noiseConstantVolumeFlag] == 1
         self.envelopePeriod = byte[.noiseVolume]
@@ -58,12 +58,12 @@ extension NoiseChannel {
         self.envelopeStart = true
     }
 
-    mutating public func updateRegister3(byte: UInt8) {
+    mutating public func writeLoopAndPeriod(byte: UInt8) {
         self.mode = byte[.noiseMode] == 1 ? 6 : 1
         self.timerPeriod = Self.timerPeriods[Int(byte[.noisePeriod])]
     }
 
-    mutating public func updateRegister4(byte: UInt8) {
+    mutating public func writeLength(byte: UInt8) {
         self.lengthCounterValue = APU.lengthTable[Int(byte[.noiseLengthCounter])]
         self.envelopeStart = true
     }

--- a/happiNESs/Channels/NoiseChannel.swift
+++ b/happiNESs/Channels/NoiseChannel.swift
@@ -5,38 +5,29 @@
 //  Created by Danielle Kefford on 10/24/24.
 //
 
-enum NoiseControlFlag {
-    case lengthCounterEnabled
-    case envelopeLoop
-}
-
 public struct NoiseChannel {
     static let timerPeriods: [UInt16] = [
         4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 4068,
     ]
 
     // TODO: Need comments explaining all these fields!!!
-    private var controlFlag: NoiseControlFlag = .lengthCounterEnabled
     private var constantVolumeFlag: Bool = false
     private var constantVolume: UInt8 = 0x00
     private var mode: Int = 1
     private var shiftRegister: UInt16 = 0x0001
-    private var timerPeriod: UInt16 = 0x0000
-    private var timerValue: UInt16 = 0x0000
 
     private var dutyIndex: Int = 0
     public var lengthCounter: LengthCounter = LengthCounter()
+    private var timer: Timer = Timer()
     private var envelope: Envelope = Envelope()
 
     mutating public func reset() {
-        self.controlFlag = .lengthCounterEnabled
         self.constantVolumeFlag = false
         self.constantVolume = 0x00
         self.mode = 1
         self.shiftRegister = 0x0001
-        self.timerPeriod = 0x0000
-        self.timerValue = 0x0000
         self.lengthCounter.reset()
+        self.timer.reset()
         self.envelope.reset()
         self.dutyIndex = 0
     }
@@ -56,7 +47,7 @@ extension NoiseChannel {
 
     mutating public func writeLoopAndPeriod(byte: UInt8) {
         self.mode = byte[.noiseMode] == 1 ? 6 : 1
-        self.timerPeriod = Self.timerPeriods[Int(byte[.noisePeriod])]
+        self.timer.period = Self.timerPeriods[Int(byte[.noisePeriod])] - 1
     }
 
     mutating public func writeLength(byte: UInt8) {
@@ -65,15 +56,11 @@ extension NoiseChannel {
     }
 
     mutating public func stepTimer() {
-        if self.timerValue == 0 {
-            self.timerValue = self.timerPeriod
-
+        if self.timer.step() {
             let bit1 = self.shiftRegister & 1
             let bit2 = (self.shiftRegister >> self.mode) & 1
             self.shiftRegister >>= 1
             self.shiftRegister |= (bit1 ^ bit2) << 14
-        } else {
-            self.timerValue -= 1
         }
     }
 

--- a/happiNESs/Channels/NoiseChannel.swift
+++ b/happiNESs/Channels/NoiseChannel.swift
@@ -50,7 +50,7 @@ extension NoiseChannel {
         self.timer.period = Self.timerPeriods[Int(byte[.noisePeriod])] - 1
     }
 
-    mutating public func writeLength(byte: UInt8) {
+    mutating public func writeLengthCounter(byte: UInt8) {
         self.lengthCounter.setValue(index: byte[.noiseLengthCounter])
         self.envelope.started = true
     }
@@ -68,7 +68,7 @@ extension NoiseChannel {
         self.envelope.step()
     }
 
-    mutating public func stepLength() {
+    mutating public func stepLengthCounter() {
         self.lengthCounter.step()
     }
 

--- a/happiNESs/Channels/PulseChannel.swift
+++ b/happiNESs/Channels/PulseChannel.swift
@@ -84,7 +84,7 @@ public struct PulseChannel {
 }
 
 extension PulseChannel {
-    mutating public func updateRegister1(byte: UInt8) {
+    mutating public func writeController(byte: UInt8) {
         self.dutyMode = Int(byte[.pulseDutyMode])
         self.controlFlag = byte[.pulseControlFlag] == 1 ? .envelopeLoop : .lengthCounterEnabled
         self.constantVolumeFlag = byte[.pulseConstantVolumeFlag] == 1
@@ -93,7 +93,7 @@ extension PulseChannel {
         self.envelopeStart = true
     }
 
-    mutating public func updateRegister2(byte: UInt8) {
+    mutating public func writeSweep(byte: UInt8) {
         self.sweepEnabled = byte[.pulseSweepEnabled] == 1
         self.sweepPeriod = byte[.pulseSweepPeriod] + 1
         self.sweepNegated = byte[.pulseSweepNegated] == 1
@@ -101,11 +101,11 @@ extension PulseChannel {
         self.sweepReloaded = true
     }
 
-    mutating public func updateRegister3(byte: UInt8) {
+    mutating public func writeTimerLow(byte: UInt8) {
         self.timerPeriod = (self.timerPeriod & 0b0000_0111_0000_0000) | UInt16(byte)
     }
 
-    mutating public func updateRegister4(byte: UInt8) {
+    mutating public func writeLengthAndTimerHigh(byte: UInt8) {
         self.lengthCounterValue = APU.lengthTable[Int(byte[.triangleLengthCounter])]
         self.timerPeriod = (self.timerPeriod & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
         self.envelopeStart = true

--- a/happiNESs/Channels/PulseChannel.swift
+++ b/happiNESs/Channels/PulseChannel.swift
@@ -86,7 +86,7 @@ extension PulseChannel {
         self.updateTargetPeriod()
     }
 
-    mutating public func writeLengthAndTimerHigh(byte: UInt8) {
+    mutating public func writeLengthCounterAndTimerHigh(byte: UInt8) {
         self.lengthCounter.setValue(index: byte[.pulseLengthCounter])
         self.timer.setValueHigh(value: byte)
         self.updateTargetPeriod()
@@ -136,7 +136,7 @@ extension PulseChannel {
         }
     }
 
-    mutating public func stepLength() {
+    mutating public func stepLengthCounter() {
         self.lengthCounter.step()
     }
 

--- a/happiNESs/Channels/Timer.swift
+++ b/happiNESs/Channels/Timer.swift
@@ -1,0 +1,40 @@
+//
+//  Timer.swift
+//  happiNESs
+//
+//  Created by Danielle Kefford on 12/31/24.
+//
+
+struct Timer {
+    public var value: UInt16 = 0
+    public var period: UInt16 = 0
+
+    mutating public func reset() {
+        self.period = 0
+        self.value = 0
+    }
+}
+
+extension Timer {
+    mutating public func setValueLow(value: UInt8) {
+        self.period = (self.period & 0b0000_0111_0000_0000) | UInt16(value)
+    }
+
+    mutating public func setValueHigh(value: UInt8) {
+        self.period = (self.period & 0b0000_0000_1111_1111) | UInt16(value[.pulseTimerHigh]) << 8
+    }
+
+    mutating public func step() -> Bool {
+        if self.value == 0 {
+            self.value = self.period
+            return true
+        }
+
+        self.value -= 1
+        return false
+    }
+
+    mutating public func reload() {
+        self.value = self.period
+    }
+}

--- a/happiNESs/Channels/TriangleChannel.swift
+++ b/happiNESs/Channels/TriangleChannel.swift
@@ -39,16 +39,16 @@ public struct TriangleChannel {
 }
 
 extension TriangleChannel {
-    mutating public func updateRegister1(byte: UInt8) {
+    mutating public func writeController(byte: UInt8) {
         self.controlFlagEnabled = byte[.triangleControlFlag] == 0
         self.linearCounterReload = byte[.triangleLinearCounterReload]
     }
 
-    mutating public func updateRegister3(byte: UInt8) {
+    mutating public func writeTimerLow(byte: UInt8) {
         self.timerPeriod = (self.timerPeriod & 0b0000_0111_0000_0000) | UInt16(byte)
     }
 
-    mutating public func updateRegister4(byte: UInt8) {
+    mutating public func writeLengthAndTimerHigh(byte: UInt8) {
         self.lengthCounterValue = APU.lengthTable[Int(byte[.triangleLengthCounter])]
         self.timerPeriod = (self.timerPeriod & 0b0000_0000_1111_1111) | UInt16(byte[.triangleTimerHigh]) << 8
         self.timerValue = self.timerPeriod + 1

--- a/happiNESs/Channels/TriangleChannel.swift
+++ b/happiNESs/Channels/TriangleChannel.swift
@@ -51,7 +51,7 @@ extension TriangleChannel {
         self.timer.setValueLow(value: byte)
     }
 
-    mutating public func writeLengthAndTimerHigh(byte: UInt8) {
+    mutating public func writeLengthCounterAndTimerHigh(byte: UInt8) {
         self.lengthCounter.setValue(index: byte[.triangleLengthCounter])
         self.timer.setValueHigh(value: byte[.triangleTimerHigh])
         self.linearCounterReload = true
@@ -65,7 +65,7 @@ extension TriangleChannel {
         }
     }
 
-    mutating public func stepCounter() {
+    mutating public func stepLinearCounter() {
         if self.linearCounterReload {
             self.linearCounterValue = self.linearCounterPeriod
         } else if self.linearCounterValue > 0 {
@@ -77,7 +77,7 @@ extension TriangleChannel {
         }
     }
 
-    mutating public func stepLength() {
+    mutating public func stepLengthCounter() {
         self.lengthCounter.step()
     }
 

--- a/happiNESs/RegisterBit.swift
+++ b/happiNESs/RegisterBit.swift
@@ -63,7 +63,7 @@ package enum RegisterBit {
     case apuFrameCounterUnused4
     case apuFrameCounterUnused5
     case apuFrameCounterUnused6
-    case frameIrqInhibited
+    case frameIrqEnabled
     case sequencerMode
 
     var bitIndex: Int {
@@ -89,7 +89,7 @@ package enum RegisterBit {
             .apuStatusUnused1, .apuFrameCounterUnused6:
             5
         case .overflow, .spriteZeroHit, .masterSlaveSelect, .emphasizeGreen,
-            .apuStatusUnused2, .frameIrqInhibited:
+            .apuStatusUnused2, .frameIrqEnabled:
             6
         case .negative, .verticalBlankStarted, .generateNmi, .emphasizeBlue,
             .apuStatusUnused3, .sequencerMode:

--- a/happiNESs/RegisterBitMask.swift
+++ b/happiNESs/RegisterBitMask.swift
@@ -9,7 +9,7 @@ enum RegisterBitMask: Register {
     case apuStatus
 
     case triangleControlFlag
-    case triangleLinearCounterReload
+    case triangleLinearCounterPeriod
 
     case triangleLengthCounter
     case triangleTimerHigh
@@ -47,7 +47,7 @@ enum RegisterBitMask: Register {
         case .apuStatus:                   0b0001_1111
 
         case .triangleControlFlag:         0b1000_0000
-        case .triangleLinearCounterReload: 0b0111_1111
+        case .triangleLinearCounterPeriod: 0b0111_1111
 
         case .triangleLengthCounter:       0b1111_1000
         case .triangleTimerHigh:           0b0000_0111

--- a/happiNESs/Tracing.swift
+++ b/happiNESs/Tracing.swift
@@ -61,7 +61,7 @@ func trace(cpu: CPU) -> String {
             partialAsm = String(format: "$%02X,Y @ %02X = %02X", nextByte, absoluteAddress, value)
         case .indirectX:
             partialAsm = String(format: "($%02X,X) @ %02X = %04X = %02X", nextByte, nextByte &+ cpu.xRegister, absoluteAddress, value)
-        case .indirectY:
+        case .indirectY, .indirectYDummyRead:
             partialAsm = String(format: "($%02X),Y = %04X @ %04X = %02X", nextByte, absoluteAddress &- UInt16(cpu.yRegister), absoluteAddress, value)
         case .relative:
             let address = if nextByte >> 7 == 0 {
@@ -94,9 +94,9 @@ func trace(cpu: CPU) -> String {
             } else {
                 partialAsm = String(format: "$%04X = %02X", absoluteAddress, value)
             }
-        case .absoluteX:
+        case .absoluteX, .absoluteXDummyRead:
             partialAsm = String(format: "$%04X,X @ %04X = %02X", address, absoluteAddress, value)
-        case .absoluteY:
+        case .absoluteY, .absoluteYDummyRead:
             partialAsm = String(format: "$%04X,Y @ %04X = %02X", address, absoluteAddress, value)
         default:
             fatalError("Unexpected addressing mode encountered while tracing!")

--- a/happiNESsTests/ROMTests.swift
+++ b/happiNESsTests/ROMTests.swift
@@ -40,4 +40,8 @@ final class ROMTests: XCTestCase {
     func testPpuVblNmi() throws {
         try testBlarggRom(romName: "ppu_vbl_nmi", cpu: self.cpu)
     }
+
+    func testApu() throws {
+        try testBlarggRom(romName: "apu_test", cpu: self.cpu)
+    }
 }


### PR DESCRIPTION
Woof... this was a lot of work to get yet another one of blargg's test suites to pass, this time the APU test ROM. The most critical changes include:

* Tweaking of the cycle figures in `APU.stepSequencer()` to get the timings right
* Introduction of a delay mechanism for when the sequencing mode is updated in the APU
* Subtle but significant changes to how IRQ's are generated in `APU.updateSequencer()` as well as in `DMCChannel`
* Introduction of `APU.readStatus()` to return the collective state of numerous parts of the APU instead of a single byte value


This new blargg ROM file, `apu_test.nes`, has also been added to this repo and is also incorporated into the unit test suite.

Additionally, there was a fair amount of refactoring in the interest of clarity, including:

* The introduction of new structs, `LinearCounter`, `LengthCounter`, `Envelope`, and `Timer`, shared by the different channel types, as well as changes to those channel types to take advantage of them
* Renaming of several methods and enum cases

There was also an unrelated bug fix for the main tracing function that had been introduced by a previous PR.