### PR TITLE
Fix glitchy audio bug

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.happiNESsApp;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = happiNESs;
@@ -754,7 +754,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.happiNESsApp;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = happiNESs;

--- a/happiNESs/APU.swift
+++ b/happiNESs/APU.swift
@@ -11,7 +11,7 @@ enum SequencerMode {
 }
 
 public struct APU {
-    public static let audioSampleRate: Float = 44100.0
+    public static let audioSampleRate: Double = 44100.0
     static let frameCounterRate = CPU.frequency / 240.0
 
     // Values for this table taken from:
@@ -28,7 +28,7 @@ public struct APU {
     private var sequencerCount: Int = 0
     private var frameIrqInhibited: Bool = false
     private var frameIrqEnabled: Bool = false
-    public var sampleRate: Float
+    public var sampleSize: Double
 
     public var pulse1: PulseChannel = PulseChannel(channelNumber: .one)
     public var pulse2: PulseChannel = PulseChannel(channelNumber: .two)
@@ -42,8 +42,8 @@ public struct APU {
     private var newSequencerValue: UInt8?
     private var newSequencerValueDelay: Int = 0
 
-    public init(sampleRate: Float) {
-        self.sampleRate = sampleRate
+    public init(sampleSize: Double) {
+        self.sampleSize = sampleSize
         // NOTA BENE: Even though according to the following section in the NESDev
         // wiki that there ought to be two high pass filters, I found that adding
         // the one for 400 Hz made the resultant audio sound way too tinny, and so
@@ -51,8 +51,8 @@ public struct APU {
         //
         //     https://www.nesdev.org/wiki/APU_Mixer
         self.filterChain = FilterChain(filters: [
-            HighPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 90),
-            LowPassFilter(sampleRate: Self.audioSampleRate, cutoffFrequency: 14000),
+            HighPassFilter(sampleRate: Float(Self.audioSampleRate), cutoffFrequency: 90),
+            LowPassFilter(sampleRate: Float(Self.audioSampleRate), cutoffFrequency: 14000),
         ])
     }
 
@@ -189,11 +189,11 @@ extension APU {
 extension APU {
     var shouldSendSample: Bool {
         // NOTA BENE: We can't just use simple modulo arithmetic here
-        // because we're dealing with Floats and Doubles and need to avoid
+        // because we're dealing with Doubles and need to avoid
         // truncation errors. For the time being, this is the most
-        // reliable way to detect if and when to send a sample.
-        let oldSampleNumber = Int(Float(self.cycles - 1) / self.sampleRate)
-        let newSampleNumber = Int(Float(self.cycles) / self.sampleRate)
+        // reliable way to detect if and when to send samples.
+        let oldSampleNumber = Int(Double(self.cycles - 1) / self.sampleSize)
+        let newSampleNumber = Int(Double(self.cycles) / self.sampleSize)
         return newSampleNumber != oldSampleNumber
     }
 

--- a/happiNESs/Bus.swift
+++ b/happiNESs/Bus.swift
@@ -22,7 +22,7 @@ public class Bus {
     public init() {
         self.ppu = PPU()
         // TODO: Need to explain this!!!
-        self.apu = APU(sampleRate: Float(CPU.frequency) / APU.audioSampleRate)
+        self.apu = APU(sampleSize: Double(CPU.frequency) / APU.audioSampleRate)
 
         self.vram = [UInt8](repeating: 0x00, count: 2048)
         self.joypad1Status = JoypadStatus()

--- a/happiNESsApp/Speaker.swift
+++ b/happiNESsApp/Speaker.swift
@@ -29,19 +29,11 @@ struct Speaker {
                                         channels: 1,
                                         interleaved: outputFormat.isInterleaved)
 
-        var cachedBufferValue: Float = 0.0
         let sourceNode = AVAudioSourceNode { [inputBuffer] _, _, frameCount, audioBufferList -> OSStatus in
             let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
 
             for frame in 0..<Int(frameCount) {
-                // NOTA BENE: Because the emulated timing between the CPU and APU
-                // is not quite accurate, the buffer is sometimes empty, and so
-                // if we put a zero value into the output buffer, the result is a
-                // popping/slapping sound. So for now, we cache the previous value
-                // of the sample and use that in the event that the buffer, resulting
-                // in a much smoother audio output.
-                let value = inputBuffer.take() ?? cachedBufferValue
-                cachedBufferValue = value
+                let value = inputBuffer.take() ?? 0.0
 
                 for outputAudioBuffer in ablPointer {
                     let outputBuffer: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(outputAudioBuffer)


### PR DESCRIPTION
I thought I had the APU and speaker emulation licked, but I discovered that if I played a game, say Super Mario Bros., for sufficient amount of time, in this case around the end of level 1-4, the audio would start glitching, begin sounding static-y. This would happen with other games too... and the problem would always start happening right around the same time. After putting `print()` calls in various places to rule out possibilities, it came down to the way in which I determine whether or not the APU should send samples to the speaker, namely in the `APU.shouldSendSample` var. Since the frequency of the CPU is 1789773.0 Hz and the APU sampling rate is 44100 Hz, the APU needs to send 40.58442177 samples at a time to keep the audio buffer sufficiently full for `Speaker` to be able to successfully pull from it. Because 40.58442177 isn't an integer (obviously), the logic for when to send samples couldn't simply involve modulo arithmetic, so instead I had resorted to this:

```
    var shouldSendSample: Bool {
        let oldSampleNumber = Int(Float(self.cycles - 1) / self.sampleRate)
        let newSampleNumber = Int(Float(self.cycles) / self.sampleRate)
        return newSampleNumber != oldSampleNumber
    }
```

However, this doesn't work after a certain amount of time... and that's because the `Float` type doesn't have enough precision after a certain point. After sprinkling some `print()` statements, I observed that at the exact moment the audio started glitching, the number of times that the emulated speaker would fail to pull a sample from the audio buffer jumped up by almost an order of magnitude:

![image](https://github.com/user-attachments/assets/7134ce44-2800-4123-8f87-6df6254256fa)

... and it turns out that when the number of cycles reaches a certain point, in this run 536910282, the gap between the actual values that `Float` can represent is 64, and because 64 is larger than 40.58442177 (obviously), the chance that the speaker will fail to pull samples from the audio buffer will increase _substantially_. And indeed, doing some arithmetic told me that this should happen right around the 5 minute mark, which is exactly what I observed when playing any game:

![image](https://github.com/user-attachments/assets/4106cb3c-4959-4e8a-948f-d97c6cdb8b7f)

And so, the solution was fairly simple: use `Double` instead of `Float`.

(The only reason why I used `Float` in the first place was because the AVFoundation API uses `Float` to represent the value of a sample. I should have known better than to confuse the types used for a _scalar value_ with that of a _rate_.)

