### PR TITLE
Get Wordle game working

### DIFF
--- a/happiNESs.xcodeproj/project.pbxproj
+++ b/happiNESs.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		878D81432C7FEE3B0076ED30 /* image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = image.xcassets; sourceTree = "<group>"; };
 		878D81462C815E760076ED30 /* NESError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NESError.swift; sourceTree = "<group>"; };
 		878DCB8C2CCAB4CC00BE7ABB /* NoiseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseChannel.swift; sourceTree = "<group>"; };
+		87930B612DE6738800CAA84F /* happiNESsTests */ = {isa = PBXFileReference; lastKnownFileType = folder; path = happiNESsTests; sourceTree = "<group>"; };
 		879F665A2D0FB1B500DF8AB1 /* Interruptible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interruptible.swift; sourceTree = "<group>"; };
 		879F66A42D125F4200DF8AB1 /* OpenBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenBus.swift; sourceTree = "<group>"; };
 		879F66A62D137E9D00DF8AB1 /* official_only.nes */ = {isa = PBXFileReference; lastKnownFileType = file; path = official_only.nes; sourceTree = "<group>"; };
@@ -324,6 +325,7 @@
 		8744B1682C1CB9B3001B44B5 = {
 			isa = PBXGroup;
 			children = (
+				87930B612DE6738800CAA84F /* happiNESsTests */,
 				878D81432C7FEE3B0076ED30 /* image.xcassets */,
 				8744B1742C1CB9B3001B44B5 /* happiNESs */,
 				8744B1802C1CB9B3001B44B5 /* happiNESsTests */,
@@ -535,7 +537,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1520;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					871931EC2C30BB2900A73C22 = {
@@ -725,7 +727,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.9.0;
+				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.happiNESsApp;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = happiNESs;
@@ -754,7 +756,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.9.0;
+				MARKETING_VERSION = 0.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.happiNESsApp;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = happiNESs;

--- a/happiNESs/CPU+execution.swift
+++ b/happiNESs/CPU+execution.swift
@@ -65,6 +65,8 @@ extension CPU {
                 self.and(addressingMode: opcode.addressingMode)
             case .aslAccumulator, .aslZeroPage, .aslZeroPageX, .aslAbsolute, .aslAbsoluteXDummyRead:
                 self.asl(addressingMode: opcode.addressingMode)
+            case .asr:
+                self.asr(addressingMode: opcode.addressingMode)
             case .bcc:
                 self.bcc()
             case .bcs:
@@ -164,6 +166,8 @@ extension CPU {
                 self.sax(addressingMode: opcode.addressingMode)
             case .sbcImmediate1, .sbcImmediate2, .sbcZeroPage, .sbcZeroPageX, .sbcAbsolute, .sbcAbsoluteX, .sbcAbsoluteY, .sbcIndirectX, .sbcIndirectY:
                 self.sbc(addressingMode: opcode.addressingMode)
+            case .sbx:
+                self.sbx(addressingMode: opcode.addressingMode)
             case .sec:
                 self.sec()
             case .sed:

--- a/happiNESs/Mappers/Uxrom.swift
+++ b/happiNESs/Mappers/Uxrom.swift
@@ -7,9 +7,11 @@
 
 class Uxrom: Mapper {
     public unowned var cartridge: Cartridge
+    private var prgBankCount: Int
 
     init(cartridge: Cartridge) {
         self.cartridge = cartridge
+        self.prgBankCount = cartridge.prgMemory.count / 0x4000
     }
 
     public func readByte(address: UInt16) -> UInt8 {
@@ -24,7 +26,7 @@ class Uxrom: Mapper {
             let memoryIndex = self.cartridge.prgBankIndex * 0x4000 + Int(address - 0x8000)
             return self.cartridge.prgMemory[Int(memoryIndex)]
         case 0xC000 ... 0xFFFF:
-            let lastBankStart = 7 * 0x4000
+            let lastBankStart = (self.prgBankCount - 1) * 0x4000
             let memoryIndex = lastBankStart + Int(address - 0xC000)
             return self.cartridge.prgMemory[Int(memoryIndex)]
         default:

--- a/happiNESs/Opcode.swift
+++ b/happiNESs/Opcode.swift
@@ -30,6 +30,8 @@ enum Opcode: UInt8 {
     case aslAbsolute = 0x0E
     case aslAbsoluteXDummyRead = 0x1E
 
+    case asr = 0x4B
+
     case bcc = 0x90
     case bcs = 0xB0
     case beq = 0xF0
@@ -238,6 +240,8 @@ enum Opcode: UInt8 {
     case sbcIndirectX = 0xE1
     case sbcIndirectY = 0xF1
 
+    case sbx = 0xCB
+
     case sec = 0x38
     case sed = 0xF8
     case sei = 0x78
@@ -311,6 +315,8 @@ extension Opcode {
         case .aslZeroPageX: .zeroPageX
         case .aslAbsolute: .absolute
         case .aslAbsoluteXDummyRead: .absoluteXDummyRead
+
+        case .asr: .immediate
 
         case .bcc: .relative
         case .bcs: .relative
@@ -520,6 +526,8 @@ extension Opcode {
         case .sbcIndirectX: .indirectX
         case .sbcIndirectY: .indirectY
 
+        case .sbx: .immediate
+
         case .sec: .implicit
         case .sed: .implicit
         case .sei: .implicit
@@ -595,6 +603,8 @@ extension Opcode {
         case .aslZeroPageX: 2
         case .aslAbsolute: 3
         case .aslAbsoluteXDummyRead: 3
+
+        case .asr: 2
 
         case .bcc: 2
         case .bcs: 2
@@ -804,6 +814,8 @@ extension Opcode {
         case .sbcIndirectX: 2
         case .sbcIndirectY: 2
 
+        case .sbx: 2
+
         case .sec: 1
         case .sed: 1
         case .sei: 1
@@ -864,7 +876,8 @@ extension Opcode {
 extension Opcode {
     var isDocumented: Bool {
         switch self {
-        case .dcpAbsolute, .dcpAbsoluteXDummyRead, .dcpAbsoluteYDummyRead, .dcpZeroPage, .dcpZeroPageX, .dcpIndirectX, .dcpIndirectYDummyRead,
+        case .asr,
+                .dcpAbsolute, .dcpAbsoluteXDummyRead, .dcpAbsoluteYDummyRead, .dcpZeroPage, .dcpZeroPageX, .dcpIndirectX, .dcpIndirectYDummyRead,
                 .isbAbsolute, .isbAbsoluteXDummyRead, .isbAbsoluteYDummyRead, .isbZeroPage, .isbZeroPageX, .isbIndirectX, .isbIndirectYDummyRead,
                 .laxImmediate, .laxZeroPage, .laxZeroPageY, .laxAbsolute, .laxAbsoluteY, .laxIndirectX, .laxIndirectY,
                 .nopImplicit1, .nopImplicit2, .nopImplicit3, .nopImplicit4, .nopImplicit5, .nopImplicit7,
@@ -877,6 +890,7 @@ extension Opcode {
                 .rraAbsolute, .rraAbsoluteXDummyRead, .rraAbsoluteYDummyRead, .rraZeroPage, .rraZeroPageX, .rraIndirectX, .rraIndirectYDummyRead,
                 .saxZeroPage, .saxZeroPageY, .saxAbsolute, .saxIndirectX,
                 .sbcImmediate2,
+                .sbx,
                 .shaAbsoluteYDummyRead, .shaIndirectYDummyRead,
                 .sloAbsolute, .sloAbsoluteXDummyRead, .sloAbsoluteYDummyRead, .sloZeroPage, .sloZeroPageX, .sloIndirectX, .sloIndirectYDummyRead,
                 .sreAbsolute, .sreAbsoluteXDummyRead, .sreAbsoluteYDummyRead, .sreZeroPage, .sreZeroPageX, .sreIndirectX, .sreIndirectYDummyRead:
@@ -913,6 +927,8 @@ extension Opcode {
         case .aslZeroPageX: 6
         case .aslAbsolute: 6
         case .aslAbsoluteXDummyRead: 7
+
+        case .asr: 2
 
         case .bcc: 2
         case .bcs: 2
@@ -1121,6 +1137,8 @@ extension Opcode {
         case .sbcAbsoluteY: 4
         case .sbcIndirectX: 6
         case .sbcIndirectY: 5
+
+        case .sbx: 2
 
         case .sec: 2
         case .sed: 2

--- a/happiNESsTests/CPUTests.swift
+++ b/happiNESsTests/CPUTests.swift
@@ -250,6 +250,17 @@ final class CPUTests: XCTestCase {
         XCTAssertTrue(cpu.status[.carry])
     }
 
+    func testAsr() {
+        let program: [UInt8] = [0xA9, 0b1111_1111, 0x4B, 0b0000_1111]
+        let cpu = makeCpu(programBytes: program)
+        cpu.executeInstructions(stoppingAfter: 2)
+
+        XCTAssertEqual(cpu.accumulator, 0b0000_0111)
+        XCTAssertTrue(!cpu.status[.zero])
+        XCTAssertTrue(!cpu.status[.negative])
+        XCTAssertTrue(cpu.status[.carry])
+    }
+
     func testBcc() {
         // NOTA BENE: This program loads the accumlator with the value 0x10,
         // then executes the `BCC` instrcution which checks if the carry bit is
@@ -1444,6 +1455,18 @@ final class CPUTests: XCTestCase {
         XCTAssertEqual(cpu.accumulator, 0x0F)
         XCTAssertTrue(cpu.status[.carry])
         XCTAssertTrue(!cpu.status[.overflow])
+        XCTAssertTrue(!cpu.status[.zero])
+        XCTAssertTrue(!cpu.status[.negative])
+    }
+
+    func testSbx() {
+        let program: [UInt8] = [0xA9, 0b1111_1111, 0xA2, 0b0000_1111, 0xCB, 0b0000_0011]
+        let cpu = makeCpu(programBytes: program)
+        cpu.executeInstructions(stoppingAfter: 3)
+
+        XCTAssertEqual(cpu.accumulator, 0b1111_1111)
+        XCTAssertEqual(cpu.xRegister, 0b0000_1100)
+        XCTAssertTrue(cpu.status[.carry])
         XCTAssertTrue(!cpu.status[.zero])
         XCTAssertTrue(!cpu.status[.negative])
     }


### PR DESCRIPTION
I had discovered the other day that someone made a version of Wordle for the NES, https://vectrex28.itch.io/wordle-nes, and I just had to try it out, but when I tried to run it in my own emulator it crashed hard. I saw right away that the problem was likely due to a problem with the mapper... but I wasn't sure if there was a bug in my implementation of the UxROM mapper, or if the wrong mapper was selected in the first place. This game is a new one made by an indie developer and so doesn't appear in any of the lists that I found relating games to mapper numbers, but I _did_ find a standalone utility that loads a ROM and shows its details, including the mapper number. After running it, it showed that the game does indeed use the UxROM mapper, which meant I there was a problem with how I was reading from, and potentially writing to, memory inside the ROM. 

It turned out that I had hardcoded the number of PRG memory banks to 7 instead of dynamically setting it based on the total size of PRG memory, and so I fixed that, reran the game... and it crashed again. This time, it was due to attempting to execute an opcode that I hadn't implemented yet, 0xCB. And that turned out to be the undocumented SBX instruction. So, I implemented that and retried and got the same error but for another opcode, 0x4B. That turned out to be _another_ undocumented NES opcode, ASR... and so I implemented that and... IT WORKED!!!

And so, this PR contains both sets of changes, as well as a couple of new unit tests, and an updated Xcode project file because somehow I had lost the ability to run unit tests.